### PR TITLE
Readds accesability escape to settings

### DIFF
--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -79,6 +79,12 @@ final class SettingsViewController: UITableViewController {
             onSignOut()
         }
     }
+    
+    // MARK: Accessibility
+    override func accessibilityPerformEscape() -> Bool {
+        onDone(self)
+        return true
+    }
 
     // MARK: Private API
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1562</string>
+	<string>1563</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
Seems like it was accidentally removed in https://github.com/rnystrom/GitHawk/commit/87150d26e4189ce676331766f500b9ef7b2dda8b.