### PR TITLE
Added the pod `HTMLString`, fixes #307

### DIFF
--- a/Classes/Issues/Comments/Markdown/CommentModelsFromMarkdown.swift
+++ b/Classes/Issues/Comments/Markdown/CommentModelsFromMarkdown.swift
@@ -9,6 +9,7 @@
 import UIKit
 import IGListKit
 import MMMarkdown
+import HTMLString
 
 private let newlineString = "\n"
 
@@ -42,8 +43,9 @@ func emptyDescriptionModel(width: CGFloat) -> ListDiffable {
 
 func CreateCommentModels(markdown: String, width: CGFloat) -> [ListDiffable] {
     let emojiMarkdown = replaceGithubEmojiRegex(string: markdown)
+    let replaceHTMLentities = emojiMarkdown.removingHTMLEntities
 
-    guard let document = createCommentAST(markdown: emojiMarkdown)
+    guard let document = createCommentAST(markdown: replaceHTMLentities)
         else { return [emptyDescriptionModel(width: width)] }
 
     var results = [ListDiffable]()

--- a/Classes/Issues/Comments/Markdown/MMElement+Table.swift
+++ b/Classes/Issues/Comments/Markdown/MMElement+Table.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import MMMarkdown
+import HTMLString
 
 private typealias Row = IssueCommentTableModel.Row
 private class TableBucket {
@@ -24,7 +25,7 @@ private func buildAttributedString(
     switch element.type {
     case .none, .entity:
         if let substr = markdown.substring(with: element.range) {
-            attributedString.append(NSAttributedString(string: substr, attributes: attributes))
+            attributedString.append(NSAttributedString(string: substr.removingHTMLEntities, attributes: attributes))
         }
     default:
         let childAttributes = PushAttributes(

--- a/Classes/Issues/Comments/Tables/IssueCommentTableModel.swift
+++ b/Classes/Issues/Comments/Tables/IssueCommentTableModel.swift
@@ -31,21 +31,12 @@ final class IssueCommentTableModel: NSObject, ListDiffable {
         }
     }
 
-    let rowHeight: CGFloat
+    let rowHeight = Styles.Sizes.labelEventHeight
     let columns: [Column]
     let totalHeight: CGFloat
 
     init(columns: [Column]) {
         self.columns = columns
-        self.rowHeight = columns.reduce(0) { currentRowHeight, column  in
-            let maxHeight: CGFloat = column.rows.reduce(0.0) { currentMaxHeight, row in
-                let textSize = row.text.computeSize(0)
-                return max(currentMaxHeight, textSize.height)
-            }
-            
-            let inset = IssueCommentTableCollectionCell.inset.top + IssueCommentTableCollectionCell.inset.bottom
-            return max(currentRowHeight, maxHeight + inset)
-        }
         self.totalHeight = CGFloat(columns.first?.rows.count ?? 0) * rowHeight
     }
 

--- a/Classes/Issues/Comments/Tables/IssueCommentTableModel.swift
+++ b/Classes/Issues/Comments/Tables/IssueCommentTableModel.swift
@@ -31,12 +31,21 @@ final class IssueCommentTableModel: NSObject, ListDiffable {
         }
     }
 
-    let rowHeight = Styles.Sizes.labelEventHeight
+    let rowHeight: CGFloat
     let columns: [Column]
     let totalHeight: CGFloat
 
     init(columns: [Column]) {
         self.columns = columns
+        self.rowHeight = columns.reduce(0) { currentRowHeight, column  in
+            let maxHeight: CGFloat = column.rows.reduce(0.0) { currentMaxHeight, row in
+                let textSize = row.text.computeSize(0)
+                return max(currentMaxHeight, textSize.height)
+            }
+            
+            let inset = IssueCommentTableCollectionCell.inset.top + IssueCommentTableCollectionCell.inset.bottom
+            return max(currentRowHeight, maxHeight + inset)
+        }
         self.totalHeight = CGFloat(columns.first?.rows.count ?? 0) * rowHeight
     }
 

--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,6 @@
 # Uncomment the next line to define a global platform for your project
 platform :ios, '10.0'
+project 'Freetime.xcodeproj'
 
 use_frameworks!
 
@@ -13,6 +14,7 @@ pod 'Apollo', '~> 0.5.6'
 pod 'TUSafariActivity', '~> 1.0.0'
 pod 'NYTPhotoViewer', '~> 1.1.0'
 pod 'FLEX', '~> 2.0', :configurations => ['Debug']
+pod 'HTMLString'
 
 target 'Freetime' do
 end

--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,5 @@
 # Uncomment the next line to define a global platform for your project
 platform :ios, '10.0'
-project 'Freetime.xcodeproj'
 
 use_frameworks!
 


### PR DESCRIPTION
Updated the Markdown parsing so it calls `HTMLString`'s `removingHTMLEntities`-method so the html entities get converted to the real deal like a Emoji
Fixed the issue that the height of a table row was hard-coded to `30` now it's being calculated and the biggest tone is used for all other rows