### PR TITLE
Removes search results when search bar textfield cleared/emptied, fixes #305

### DIFF
--- a/Classes/Search/SearchViewController.swift
+++ b/Classes/Search/SearchViewController.swift
@@ -157,6 +157,15 @@ SearchRecentHeaderSectionControllerDelegate {
     }
 
     // MARK: UISearchBarDelegate
+    
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        guard let term = searchBar.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+            term.characters.count > 0 else {
+                state = .idle
+                update(animated: false)
+                return
+        }
+    }
 
     func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
         searchBar.setShowsCancelButton(true, animated: true)

--- a/Classes/Search/SearchViewController.swift
+++ b/Classes/Search/SearchViewController.swift
@@ -160,11 +160,10 @@ SearchRecentHeaderSectionControllerDelegate {
     
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         guard let term = searchBar.text?.trimmingCharacters(in: .whitespacesAndNewlines),
-            term.characters.count > 0 else {
-                state = .idle
-                update(animated: false)
-                return
-        }
+            term.characters.isEmpty else { return }
+        
+        state = .idle
+        update(animated: false)
     }
 
     func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {


### PR DESCRIPTION
As system restricts Cancel button on iPad, added an option to remove search results and show recent searches when search bar text field is cleared.