### PR TITLE
Allow relative images to display in README files

### DIFF
--- a/Classes/Issues/Comments/Html/IssueCommentHtmlCell.swift
+++ b/Classes/Issues/Comments/Html/IssueCommentHtmlCell.swift
@@ -58,6 +58,7 @@ final class IssueCommentHtmlCell: UICollectionViewCell, ListBindable, UIWebViewD
 
     @objc private let webView = UIWebView()
     private var body = ""
+    var webViewBaseURL: URL?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -98,14 +99,21 @@ final class IssueCommentHtmlCell: UICollectionViewCell, ListBindable, UIWebViewD
     func bindViewModel(_ viewModel: Any) {
         guard let viewModel = viewModel as? IssueCommentHtmlModel else { return }
         body = viewModel.html
+        webViewBaseURL = viewModel.baseURL
+        
         let html = IssueCommentHtmlCell.htmlHead + body + IssueCommentHtmlCell.htmlTail
-        webView.loadHTMLString(html, baseURL: nil)
+        webView.loadHTMLString(html, baseURL: webViewBaseURL)
     }
 
     // MARK: UIWebViewDelegate
 
     func webView(_ webView: UIWebView, shouldStartLoadWith request: URLRequest, navigationType: UIWebViewNavigationType) -> Bool {
         guard let url = request.url else { return true }
+        
+        if let baseURL = webViewBaseURL, url == baseURL {
+            return true
+        }
+        
         let htmlLoad = url.absoluteString == "about:blank"
         if !htmlLoad {
             navigationDelegate?.webViewWantsNavigate(cell: self, url: url)

--- a/Classes/Issues/Comments/Html/IssueCommentHtmlModel.swift
+++ b/Classes/Issues/Comments/Html/IssueCommentHtmlModel.swift
@@ -12,9 +12,11 @@ import IGListKit
 final class IssueCommentHtmlModel: NSObject, ListDiffable {
 
     let html: String
+    let baseURL: URL?
 
-    init(html: String) {
+    init(html: String, baseURL: URL? = nil) {
         self.html = html
+        self.baseURL = baseURL
     }
 
     // MARK: ListDiffable

--- a/Classes/Issues/Comments/Markdown/CommentModelsFromMarkdown.swift
+++ b/Classes/Issues/Comments/Markdown/CommentModelsFromMarkdown.swift
@@ -146,7 +146,7 @@ func needsNewline(element: MMElement) -> Bool {
     }
 }
 
-func createModel(markdown: String, element: MMElement) -> ListDiffable? {
+func createModel(markdown: String, element: MMElement, owner: String?, repo: String?) -> ListDiffable? {
     switch element.type {
     case .codeBlock:
         return CreateCodeBlock(element: element, markdown: markdown)
@@ -158,7 +158,13 @@ func createModel(markdown: String, element: MMElement) -> ListDiffable? {
         guard let html = markdown.substring(with: element.range)?.trimmingCharacters(in: .whitespacesAndNewlines),
             html.characters.count > 0
             else { return nil }
-        return IssueCommentHtmlModel(html: html)
+        
+        let baseURL: URL? = {
+            guard let owner = owner, let repo = repo else { return nil }
+            return URL(string: "https://github.com/\(owner)/\(repo)/raw/master")
+        }()
+        
+        return IssueCommentHtmlModel(html: html, baseURL: baseURL)
     case .horizontalRule:
         return IssueCommentHrModel()
     default: return nil
@@ -238,7 +244,7 @@ func travelAST(
         attributedString.append(NSAttributedString(string: modifier, attributes: pushedAttributes))
     }
 
-    let model = createModel(markdown: markdown, element: element)
+    let model = createModel(markdown: markdown, element: element, owner: owner, repo: repo)
 
     // if a model exists, push a new model with the current text stack _before_ the model. remember to drain the text
     if let model = model {

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1842</string>
+	<string>1852</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
Relates to #314 

So this does fix the issue in the GitHawk README, but we're still going to have issues with links going to relative destinations such as to a guide MD file or similar.

Thinking we need to check the file extension, see what the type is?

@rnystrom Advice?