### PR TITLE
Always dismiss keyboard on search result selection

### DIFF
--- a/Classes/Search/SearchResultSectionController.swift
+++ b/Classes/Search/SearchResultSectionController.swift
@@ -8,12 +8,18 @@
 
 import IGListKit
 
+protocol SearchResultSectionControllerDelegate {
+    func didSelect(result: SearchRepoResult)
+}
+
 final class SearchResultSectionController: ListGenericSectionController<SearchRepoResult> {
 
     private let client: GithubClient
-    
-    init(client: GithubClient) {
+    private let delegate: SearchResultSectionControllerDelegate
+
+    init(client: GithubClient, delegate: SearchResultSectionControllerDelegate) {
         self.client = client
+        self.delegate = delegate
         super.init()
     }
     
@@ -34,6 +40,7 @@ final class SearchResultSectionController: ListGenericSectionController<SearchRe
     
     override func didSelectItem(at index: Int) {
         guard let object = object else { return }
+        delegate.didSelect(result: object)
         let repo = RepositoryDetails(owner: object.owner, name: object.name, hasIssuesEnabled: object.hasIssuesEnabled)
         let repoViewController = RepositoryViewController(client: client, repo: repo)
         let navigation = UINavigationController(rootViewController: repoViewController)

--- a/Classes/Search/SearchViewController.swift
+++ b/Classes/Search/SearchViewController.swift
@@ -15,7 +15,8 @@ class SearchViewController: UIViewController,
     UISearchBarDelegate,
 SearchEmptyViewDelegate,
 SearchRecentSectionControllerDelegate,
-SearchRecentHeaderSectionControllerDelegate {
+SearchRecentHeaderSectionControllerDelegate,
+SearchResultSectionControllerDelegate {
 
     private let client: GithubClient
     private let noResultsKey = "com.freetime.SearchViewController.no-results-key" as ListDiffable
@@ -135,7 +136,7 @@ SearchRecentHeaderSectionControllerDelegate {
         } else if object === recentHeaderKey {
             return SearchRecentHeaderSectionController(delegate: self)
         } else if object is SearchRepoResult {
-            return SearchResultSectionController(client: client)
+            return SearchResultSectionController(client: client, delegate: self)
         } else if object is String {
             return SearchRecentSectionController(delegate: self)
         }
@@ -189,6 +190,12 @@ SearchRecentHeaderSectionControllerDelegate {
         
         state = .idle
         update(animated: false)
+    }
+
+    // MARK: SearchResultSectionControllerDelegate
+
+    func didSelect(result: SearchRepoResult) {
+        searchBar.resignFirstResponder()
     }
     
     // MARK: SearchEmptyViewDelegate


### PR DESCRIPTION
Issue:

It appears that https://github.com/rnystrom/GitHawk/commit/66bdf3d835528bba22c8a0ff64e7b8d958178bf0 introduced a bug with search result selection.

After the change from `navigationController.pushViewController` to `showDetailViewController`, it was possible to enter a state where the `RepositoryViewController` would be pushed onto the stack without dismissing the keyboard.

To recreate:

1. Have at least 1 recent search.
2. Select a recent search item.
3. Tap in the search bar to make it the first responder.
4. Select an item in the list from the original search results.
5. RepositoryViewController will be pushed onto the stack, but the keyboard will remain visible.

Solution:

Declare and implement `SearchResultSectionControllerDelegate`. This delegate is used to notify the `SearchViewController` that a search result has been selected.

In turn, the `SearchViewController` will resign first responder status of its search bar.