### PR TITLE
Improve compile times (Issue #114)

### DIFF
--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -1674,7 +1674,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "APOLLO_FRAMEWORK_PATH=\"$(eval find $FRAMEWORK_SEARCH_PATHS -name \"Apollo.framework\" -maxdepth 1)\"\n\nif [ -z \"$APOLLO_FRAMEWORK_PATH\" ]; then\necho \"error: Couldn't find Apollo.framework in FRAMEWORK_SEARCH_PATHS; make sure to add the framework to your project.\"\nexit 1\nfi\n\ncd \"${SRCROOT}/gql\"\n$APOLLO_FRAMEWORK_PATH/check-and-run-apollo-codegen.sh generate $(find . -name '*.graphql') --schema schema.json --output API.swift";
+			shellScript = "APOLLO_FRAMEWORK_PATH=\"$(eval find $FRAMEWORK_SEARCH_PATHS -name \"Apollo.framework\" -maxdepth 1)\"\n\nif [ -z \"$APOLLO_FRAMEWORK_PATH\" ]; then\necho \"error: Couldn't find Apollo.framework in FRAMEWORK_SEARCH_PATHS; make sure to add the framework to your project.\"\nexit 1\nfi\n\ncd \"${SRCROOT}/gql\"\nTEMP_FILE=$(mktemp)\n\n[[ -f API.swift ]] || touch API.swift # ensure sure file exists\n\n$APOLLO_FRAMEWORK_PATH/check-and-run-apollo-codegen.sh generate $(find . -name '*.graphql') --schema schema.json --output $TEMP_FILE\n\ncmp API.swift $TEMP_FILE || cp $TEMP_FILE API.swift";
 		};
 		2CC988A6FBEAF3F744A53C18 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Re: #114 

_This fix dropped my average re-build (no code changes) time from 60-90 seconds to 7-10 seconds._

### Summary

It appears to me that the largest contributor to compile times is `API.swift` and its re-generation in the "Generate Apollo GraphQL API" build phase.

The build script currently overwrites `API.swift` on every build, resulting in a new last-modified timestamp. As such, the swift compiler won't use its cached build of the file.  (You'll have to excuse me, I don't know much about the compiler, so I may be butchering terminology.)

In my estimation, this causes XCode to not only recompile `API.swift`, but also _all files that reference its contents_.

### Fix

Modify the "Generate Apollo GraphQL API" build phase to only overwrite `API.swift` if the output of `check-and-run-apollo-codegen.sh` results in a different output than the previous build.

The diff is hard to read, as it's in the pbxproj, so I've included the relevant lines below:

```sh
TEMP_FILE=$(mktemp)
[[ -f API.swift ]] || touch API.swift # ensure sure file exists

$APOLLO_FRAMEWORK_PATH/check-and-run-apollo-codegen.sh generate $(find . -name '*.graphql') --schema schema.json --output $TEMP_FILE

cmp API.swift $TEMP_FILE || cp $TEMP_FILE API.swift
```

In short, it outputs the generated API file to `TEMP_FILE`. Then, it
uses `cmp` to test if `TEMP_FILE` is identifical to the existing `API.swift`. If they are not, it overrwrites `API.swift` with the newly generated code.