### PR TITLE
[WIP] Adds "view repository" alert action from Issues

### DIFF
--- a/Classes/Issues/GithubClient+Issues.swift
+++ b/Classes/Issues/GithubClient+Issues.swift
@@ -112,7 +112,8 @@ extension GithubClient {
                         milestone: milestoneModel,
                         mentionableUsers: mentionableUsers,
                         timelinePages: [newPage] + (prependResult?.timelinePages ?? []),
-                        viewerCanUpdate: issueType.viewerCanUpdate
+                        viewerCanUpdate: issueType.viewerCanUpdate,
+                        hasIssuesEnabled: repository?.hasIssuesEnabled ?? false
                     )
 
                     DispatchQueue.main.async {

--- a/Classes/Issues/IssueResult.swift
+++ b/Classes/Issues/IssueResult.swift
@@ -24,6 +24,7 @@ struct IssueResult {
     let mentionableUsers: [AutocompleteUser]
     let timelinePages: [IssueTimelinePage]
     let viewerCanUpdate: Bool
+    let hasIssuesEnabled: Bool
 
     var timelineViewModels: [ListDiffable] {
         return timelinePages.reduce([], { $0 + $1.viewModels })

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -239,6 +239,23 @@ IssueTextActionsViewDelegate {
             self?.setStatus(close: close)
         })
     }
+    
+    func viewRepoAction() -> UIAlertAction? {
+        guard let result = current else {
+            return nil
+        }
+        
+        let repo = RepositoryDetails(
+            owner: model.owner,
+            name: model.repo,
+            hasIssuesEnabled: current?.hasIssuesEnabled ?? false
+        )
+        let repoViewController = RepositoryViewController(client: client, repo: repo)
+        return UIAlertAction(title: NSLocalizedString("Open Repository", comment: ""), style: .default) { [weak self] _ in
+            guard let strongSelf = self else { return }
+            strongSelf.show(repoViewController, sender: nil)
+        }
+    }
 
     func onMore(sender: UIBarButtonItem) {
 		let alert = UIAlertController.configured(preferredStyle: .actionSheet)
@@ -249,6 +266,9 @@ IssueTextActionsViewDelegate {
 
         alert.addAction(shareAction(sender: sender))
         alert.addAction(safariAction())
+        if let viewRepo = viewRepoAction() {
+            alert.addAction(viewRepo)
+        }
         alert.addAction(UIAlertAction(title: Strings.cancel, style: .cancel))
         alert.popoverPresentationController?.barButtonItem = sender
         present(alert, animated: true)

--- a/gql/API.swift
+++ b/gql/API.swift
@@ -194,6 +194,7 @@ public final class IssueOrPullRequestQuery: GraphQLQuery {
     "  repository(owner: $owner, name: $repo) {" +
     "    __typename" +
     "    name" +
+    "    hasIssuesEnabled" +
     "    mentionableUsers(first: 100) {" +
     "      __typename" +
     "      nodes {" +
@@ -741,6 +742,8 @@ public final class IssueOrPullRequestQuery: GraphQLQuery {
       public let __typename: String
       /// The name of the repository.
       public let name: String
+      /// Indicates if the repository has issues feature enabled.
+      public let hasIssuesEnabled: Bool
       /// A list of Users that can be mentioned in the context of the repository.
       public let mentionableUsers: MentionableUser
       /// Returns a single issue-like object from the current repository by number.
@@ -749,6 +752,7 @@ public final class IssueOrPullRequestQuery: GraphQLQuery {
       public init(reader: GraphQLResultReader) throws {
         __typename = try reader.value(for: Field(responseName: "__typename"))
         name = try reader.value(for: Field(responseName: "name"))
+        hasIssuesEnabled = try reader.value(for: Field(responseName: "hasIssuesEnabled"))
         mentionableUsers = try reader.value(for: Field(responseName: "mentionableUsers", arguments: ["first": 100]))
         issueOrPullRequest = try reader.optionalValue(for: Field(responseName: "issueOrPullRequest", arguments: ["number": reader.variables["number"]]))
       }

--- a/gql/IssueOrPullRequest.graphql
+++ b/gql/IssueOrPullRequest.graphql
@@ -1,6 +1,7 @@
 query IssueOrPullRequest($owner: String!, $repo: String!, $number: Int!, $page_size: Int!, $before: String) {
   repository(owner: $owner, name: $repo) {
     name
+    hasIssuesEnabled
     mentionableUsers(first: 100) {
       nodes {
         avatarUrl


### PR DESCRIPTION
Closes #412 

- Get `hasIssuesEnabled` on repo level when querying for `IssueOrPullRequest` (In case if you have a better idea without modifying graphql, do let me know.)
- Adds "View Repository" alert action on issues/PR's and opens Repository view controller

For now, it is possible to go deep into navigation like Search -> Repo -> Issues -> Open Repo -> ...
Should we avoid this behaviour and show "Open Repo" only on issues from notifications? 

