### PR TITLE
Fixes report bug navigations for iPad

### DIFF
--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -9,7 +9,8 @@
 import UIKit
 import SafariServices
 
-final class SettingsViewController: UITableViewController {
+final class SettingsViewController: UITableViewController,
+NewIssueTableViewControllerDelegate {
 
     // must be injected
     var sessionManager: GithubSessionManager!
@@ -75,6 +76,7 @@ final class SettingsViewController: UITableViewController {
         if cell === reviewAccessCell {
             onReviewAccess()
         } else if cell === reportBugCell {
+            tableView.deselectRow(at: indexPath, animated: true)
             onReportBug()
         } else if cell === viewSourceCell {
             onViewSource()
@@ -101,9 +103,10 @@ final class SettingsViewController: UITableViewController {
             StatusBar.showGenericError()
             return
         }
-        
+        viewController.delegate = self
         let navController = UINavigationController(rootViewController: viewController)
-        showDetailViewController(navController, sender: nil)
+        navController.modalPresentationStyle = .formSheet
+        present(navController, animated: true)
     }
 
     func onViewSource() {
@@ -210,4 +213,11 @@ final class SettingsViewController: UITableViewController {
         Signature.enabled = signatureSwitch.isOn
     }
     
+    // MARK: NewIssueTableViewControllerDelegate
+    
+    func didDismissAfterCreatingIssue(model: IssueDetailsModel) {
+        let issuesViewController = IssuesViewController(client: client, model: model)
+        let navigation = UINavigationController(rootViewController: issuesViewController)
+        showDetailViewController(navigation, sender: nil)
+    }
 }


### PR DESCRIPTION
- Adds `NewIssueTableViewControllerDelegate`  to settings view controller
- Navigate to Issues view controller after submitting new issue from "Report a bug"
- Present new issue view controller with `formsheet` style so it can work fine on iPad

Closes #468 , #469 and #467 