### PR TITLE
Fix landscape view overlap for Login

### DIFF
--- a/Classes/Login/OauthLogin.storyboard
+++ b/Classes/Login/OauthLogin.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="bA6-il-lQA">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="bA6-il-lQA">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -7,6 +7,7 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -19,10 +20,6 @@
         <scene sceneID="yQn-wv-qWF">
             <objects>
                 <viewController id="bA6-il-lQA" customClass="LoginSplashViewController" customModule="Freetime" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="0F3-e6-Obo"/>
-                        <viewControllerLayoutGuide type="bottom" id="tge-zT-2RL"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="hgy-EE-Whp">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -80,26 +77,27 @@
                             <constraint firstItem="Cfb-Yp-akO" firstAttribute="top" secondItem="ai9-fN-d9O" secondAttribute="bottom" constant="16" id="4wW-6U-JTs">
                                 <variation key="heightClass=compact" constant="8"/>
                             </constraint>
-                            <constraint firstItem="A5X-Ud-TSJ" firstAttribute="top" secondItem="0F3-e6-Obo" secondAttribute="bottom" constant="8" symbolic="YES" id="6EP-Ng-PYj"/>
-                            <constraint firstItem="joJ-g2-qXR" firstAttribute="leading" secondItem="hgy-EE-Whp" secondAttribute="leading" constant="15" id="7Wi-n0-mdX"/>
+                            <constraint firstItem="A5X-Ud-TSJ" firstAttribute="top" secondItem="wI4-ER-h6s" secondAttribute="top" constant="8" id="6EP-Ng-PYj"/>
+                            <constraint firstItem="joJ-g2-qXR" firstAttribute="leading" secondItem="wI4-ER-h6s" secondAttribute="leading" constant="15" id="7Wi-n0-mdX"/>
                             <constraint firstItem="aQ2-N2-0DI" firstAttribute="centerY" secondItem="joJ-g2-qXR" secondAttribute="centerY" id="9cF-kc-dvN"/>
                             <constraint firstItem="ai9-fN-d9O" firstAttribute="centerY" secondItem="hgy-EE-Whp" secondAttribute="centerY" constant="-55" id="AqW-dx-Q2p">
                                 <variation key="heightClass=compact" constant="-85"/>
                             </constraint>
-                            <constraint firstItem="ai9-fN-d9O" firstAttribute="centerX" secondItem="hgy-EE-Whp" secondAttribute="centerX" id="G4h-6x-06I"/>
-                            <constraint firstItem="aQ2-N2-0DI" firstAttribute="leading" secondItem="hgy-EE-Whp" secondAttribute="leading" constant="30" id="Lhd-GD-T8D"/>
-                            <constraint firstAttribute="trailing" secondItem="N6P-rW-9YX" secondAttribute="trailing" constant="32" id="Mz7-1t-b2h"/>
-                            <constraint firstItem="N6P-rW-9YX" firstAttribute="leading" secondItem="hgy-EE-Whp" secondAttribute="leading" constant="32" id="Qmk-hr-wAd"/>
-                            <constraint firstItem="Cfb-Yp-akO" firstAttribute="centerX" secondItem="hgy-EE-Whp" secondAttribute="centerX" id="So4-Be-Mn4"/>
+                            <constraint firstItem="ai9-fN-d9O" firstAttribute="centerX" secondItem="wI4-ER-h6s" secondAttribute="centerX" id="G4h-6x-06I"/>
+                            <constraint firstItem="aQ2-N2-0DI" firstAttribute="leading" secondItem="wI4-ER-h6s" secondAttribute="leading" constant="30" id="Lhd-GD-T8D"/>
+                            <constraint firstItem="wI4-ER-h6s" firstAttribute="trailing" secondItem="N6P-rW-9YX" secondAttribute="trailing" constant="32" id="Mz7-1t-b2h"/>
+                            <constraint firstItem="N6P-rW-9YX" firstAttribute="leading" secondItem="wI4-ER-h6s" secondAttribute="leading" constant="32" id="Qmk-hr-wAd"/>
+                            <constraint firstItem="Cfb-Yp-akO" firstAttribute="centerX" secondItem="wI4-ER-h6s" secondAttribute="centerX" id="So4-Be-Mn4"/>
                             <constraint firstItem="N6P-rW-9YX" firstAttribute="top" secondItem="Cfb-Yp-akO" secondAttribute="bottom" constant="32" id="T1X-l4-dG1">
                                 <variation key="heightClass=compact" constant="16"/>
                             </constraint>
-                            <constraint firstAttribute="trailing" secondItem="joJ-g2-qXR" secondAttribute="trailing" constant="15" id="c3F-OZ-fRS"/>
+                            <constraint firstItem="wI4-ER-h6s" firstAttribute="trailing" secondItem="joJ-g2-qXR" secondAttribute="trailing" constant="15" id="c3F-OZ-fRS"/>
                             <constraint firstAttribute="trailingMargin" secondItem="A5X-Ud-TSJ" secondAttribute="trailing" id="geW-JD-xI0"/>
-                            <constraint firstItem="tge-zT-2RL" firstAttribute="top" secondItem="joJ-g2-qXR" secondAttribute="bottom" constant="30" id="t7W-9f-BhD">
+                            <constraint firstItem="wI4-ER-h6s" firstAttribute="bottom" secondItem="joJ-g2-qXR" secondAttribute="bottom" constant="30" id="t7W-9f-BhD">
                                 <variation key="heightClass=compact" constant="15"/>
                             </constraint>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="wI4-ER-h6s"/>
                     </view>
                     <connections>
                         <outlet property="activityIndicator" destination="aQ2-N2-0DI" id="aEQ-Lx-iG0"/>

--- a/Classes/Login/OauthLogin.storyboard
+++ b/Classes/Login/OauthLogin.storyboard
@@ -43,6 +43,14 @@
                             </button>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="splash" translatesAutoresizingMaskIntoConstraints="NO" id="ai9-fN-d9O">
                                 <rect key="frame" x="100.5" y="191.5" width="174" height="174"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="174" id="42V-gr-pfO">
+                                        <variation key="heightClass=compact" constant="140"/>
+                                    </constraint>
+                                    <constraint firstAttribute="width" constant="174" id="tK6-2i-UMP">
+                                        <variation key="heightClass=compact" constant="140"/>
+                                    </constraint>
+                                </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to GitHawk" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cfb-Yp-akO">
                                 <rect key="frame" x="50" y="381.5" width="275.5" height="38.5"/>
@@ -69,20 +77,28 @@
                         </subviews>
                         <color key="backgroundColor" red="0.96470588235294119" green="0.97254901960784312" blue="0.98039215686274506" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="Cfb-Yp-akO" firstAttribute="top" secondItem="ai9-fN-d9O" secondAttribute="bottom" constant="16" id="4wW-6U-JTs"/>
+                            <constraint firstItem="Cfb-Yp-akO" firstAttribute="top" secondItem="ai9-fN-d9O" secondAttribute="bottom" constant="16" id="4wW-6U-JTs">
+                                <variation key="heightClass=compact" constant="8"/>
+                            </constraint>
                             <constraint firstItem="A5X-Ud-TSJ" firstAttribute="top" secondItem="0F3-e6-Obo" secondAttribute="bottom" constant="8" symbolic="YES" id="6EP-Ng-PYj"/>
                             <constraint firstItem="joJ-g2-qXR" firstAttribute="leading" secondItem="hgy-EE-Whp" secondAttribute="leading" constant="15" id="7Wi-n0-mdX"/>
                             <constraint firstItem="aQ2-N2-0DI" firstAttribute="centerY" secondItem="joJ-g2-qXR" secondAttribute="centerY" id="9cF-kc-dvN"/>
-                            <constraint firstItem="ai9-fN-d9O" firstAttribute="centerY" secondItem="hgy-EE-Whp" secondAttribute="centerY" constant="-55" id="AqW-dx-Q2p"/>
+                            <constraint firstItem="ai9-fN-d9O" firstAttribute="centerY" secondItem="hgy-EE-Whp" secondAttribute="centerY" constant="-55" id="AqW-dx-Q2p">
+                                <variation key="heightClass=compact" constant="-85"/>
+                            </constraint>
                             <constraint firstItem="ai9-fN-d9O" firstAttribute="centerX" secondItem="hgy-EE-Whp" secondAttribute="centerX" id="G4h-6x-06I"/>
                             <constraint firstItem="aQ2-N2-0DI" firstAttribute="leading" secondItem="hgy-EE-Whp" secondAttribute="leading" constant="30" id="Lhd-GD-T8D"/>
                             <constraint firstAttribute="trailing" secondItem="N6P-rW-9YX" secondAttribute="trailing" constant="32" id="Mz7-1t-b2h"/>
                             <constraint firstItem="N6P-rW-9YX" firstAttribute="leading" secondItem="hgy-EE-Whp" secondAttribute="leading" constant="32" id="Qmk-hr-wAd"/>
                             <constraint firstItem="Cfb-Yp-akO" firstAttribute="centerX" secondItem="hgy-EE-Whp" secondAttribute="centerX" id="So4-Be-Mn4"/>
-                            <constraint firstItem="N6P-rW-9YX" firstAttribute="top" secondItem="Cfb-Yp-akO" secondAttribute="bottom" constant="32" id="T1X-l4-dG1"/>
+                            <constraint firstItem="N6P-rW-9YX" firstAttribute="top" secondItem="Cfb-Yp-akO" secondAttribute="bottom" constant="32" id="T1X-l4-dG1">
+                                <variation key="heightClass=compact" constant="16"/>
+                            </constraint>
                             <constraint firstAttribute="trailing" secondItem="joJ-g2-qXR" secondAttribute="trailing" constant="15" id="c3F-OZ-fRS"/>
                             <constraint firstAttribute="trailingMargin" secondItem="A5X-Ud-TSJ" secondAttribute="trailing" id="geW-JD-xI0"/>
-                            <constraint firstItem="tge-zT-2RL" firstAttribute="top" secondItem="joJ-g2-qXR" secondAttribute="bottom" constant="30" id="t7W-9f-BhD"/>
+                            <constraint firstItem="tge-zT-2RL" firstAttribute="top" secondItem="joJ-g2-qXR" secondAttribute="bottom" constant="30" id="t7W-9f-BhD">
+                                <variation key="heightClass=compact" constant="15"/>
+                            </constraint>
                         </constraints>
                     </view>
                     <connections>


### PR DESCRIPTION
Fixes #480 

- Using [size classes](https://developer.apple.com/library/content/featuredarticles/ViewControllerPGforiPhoneOS/TheAdaptiveModel.html#//apple_ref/doc/uid/TP40007457-CH19-SW4), I've tweaked the layout for the `Compact Height` size class which only affects iPhones in landscape.
- iPad remains unchanged


### Changes:
- For the existing vertical spacing constraints:
  - I've approximately halved them for landscape
- Due to layout issues with the iPhone 5/5S/5SE:
  - For all size classes, I've fixed the width and height to the logo image size (174x174)
  - I've then opted to reduce the size to about 80% of the original size for the `Compact Height` size class
  - I've decided on this percentage as I felt it was the reduction that looked the best but I'm open to changes! See my percentage comparisons [here](https://gist.github.com/ajfigueroa/ece4cb636058a3c4d8b0aeb76d59d1b1)

### Screenshots

#### iPhone 5
![simulator screen shot - iphone 5s - 2017-10-02 at 01 11 02](https://user-images.githubusercontent.com/3321592/31065348-7a09b86c-a712-11e7-91fe-8e96a766002d.png)

#### iPhone 6
![simulator screen shot - iphone 6s - 2017-10-02 at 01 11 56](https://user-images.githubusercontent.com/3321592/31065349-7a124e82-a712-11e7-9ffe-d67763eea04e.png)

#### iPhone 6+

![simulator screen shot - iphone 6s plus - 2017-10-02 at 01 12 29](https://user-images.githubusercontent.com/3321592/31065350-7a14155a-a712-11e7-9d53-34ab98c75522.png)

#### iPhone X
![simulator screen shot - iphone x - 2017-10-02 at 01 13 11](https://user-images.githubusercontent.com/3321592/31065351-7a1728f8-a712-11e7-9936-0a2d6fb16d78.png)
