### PR TITLE
Adds nav links for "Download App" and "View Resource" on blog

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -20,6 +20,8 @@
 
         <div class="trigger">
           <a class="page-link" href="http://githawk.com">Home</a>
+          <a class="page-link" href="https://itunes.apple.com/app/id1252320249">Download App</a>
+          <a class="page-link" href="https://github.com/rnystrom/GitHawk">View Source</a>
           {% for path in page_paths %}
             {% assign my_page = site.pages | where: "path", path | first %}
             {% if my_page.title %}


### PR DESCRIPTION
Closes #437 

Added two navbar links on the blog website.

- Download app - redirects to App store
- View Resource - redirects to Githawk Repo page

This is how it looks.

On PC browser:
![screen shot 2017-10-11 at 11 41 18 am](https://user-images.githubusercontent.com/12063704/31424775-c5614442-ae79-11e7-9f8a-a8f14daa05af.png)

On Smart Phones:
![screen shot 2017-10-11 at 11 41 36 am](https://user-images.githubusercontent.com/12063704/31424790-ddb3643a-ae79-11e7-9840-c4835a152550.png)
