### PR TITLE
Adds authors support of blog

### DIFF
--- a/docs/_data/authors.yml
+++ b/docs/_data/authors.yml
@@ -1,0 +1,7 @@
+# Author details.
+ryannystrom:
+    name: Ryan Nystrom
+    web: https://twitter.com/_ryannystrom
+basthomas:
+    name: Bas Broek
+    web: https://twitter.com/basthomas

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -1,0 +1,29 @@
+---
+layout: default
+---
+<article class="post" itemscope itemtype="http://schema.org/BlogPosting">
+
+  <header class="post-header">
+    <h1 class="post-title" itemprop="name headline">{{ page.title | escape }}</h1>
+    <p class="post-meta">
+      <time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
+        {% assign date_format = site.minima.date_format | default: "%b %-d, %Y" %}
+        {{ page.date | date: date_format }}
+      </time>
+      {% assign author = site.data.authors[page.author] %}
+		{% if author %}
+    	<span>
+        	- Written by <a href="{{ author.web }}" target="_blank">{{ author.name }}</a>
+    	</span>
+		{% endif %}
+	</p>
+  </header>
+
+  <div class="post-content" itemprop="articleBody">
+    {{ content }}
+  </div>
+
+  {% if site.disqus.shortname %}
+    {% include disqus_comments.html %}
+  {% endif %}
+</article>

--- a/docs/_posts/2017-08-16-Rebranding.md
+++ b/docs/_posts/2017-08-16-Rebranding.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+author: ryannystrom
 title: Rebranding
 ---
 

--- a/docs/_posts/2017-09-26-Accessibility-in-GitHawk.md
+++ b/docs/_posts/2017-09-26-Accessibility-in-GitHawk.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+author: basthomas
 title: Accessibility in GitHawk
 ---
 

--- a/docs/_posts/2017-10-02-GitHawk-Status-September-2017.md
+++ b/docs/_posts/2017-10-02-GitHawk-Status-September-2017.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+author: ryannystrom
 title: GitHawk Stats - September 2017
 ---
 

--- a/docs/_posts/2017-8-30-Finding-Your-App-Name.md
+++ b/docs/_posts/2017-8-30-Finding-Your-App-Name.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+author: ryannystrom
 title: Finding Your App Name
 ---
 


### PR DESCRIPTION
Closes #444 

Adds author support for the blog posts. We were using "minima" default theme, so copied `page.html` from the theme repo and edited to support the author. 

 - Authors list is defined in `_data/authors.yml` 
 -  If a post has `author` tag, post HTML will automatically add "Written By - Author Name"
 -  Clicking Author name will redirect to web link which is defined in YML file
 - Added authors for all current posts

Sample Post:
![screen shot 2017-10-11 at 12 21 53 pm](https://user-images.githubusercontent.com/12063704/31426133-bb69adca-ae7f-11e7-851a-0940aaedd1ff.png)
