### PR TITLE
[DO NOT MERGE] Add large titles

### DIFF
--- a/Classes/Notifications/NotificationsViewController.swift
+++ b/Classes/Notifications/NotificationsViewController.swift
@@ -56,6 +56,10 @@ TabNavRootViewControllerType {
         resetRightBarItem()
 
         navigationController?.tabBarItem.badgeColor = Styles.Colors.Red.medium.color
+        if #available(iOS 11.0, *) {
+            navigationController?.navigationBar.prefersLargeTitles = true
+            navigationItem.largeTitleDisplayMode = .automatic
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -49,6 +49,11 @@ NewIssueTableViewControllerDelegate {
             name: NSNotification.Name.UIApplicationDidBecomeActive,
             object: nil
         )
+
+        if #available(iOS 11.0, *) {
+            navigationController?.navigationBar.prefersLargeTitles = true
+            navigationItem.largeTitleDisplayMode = .automatic
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1997</string>
+	<string>2000</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
As per #523.

Not sure if I like it that much. There's also a bug with this in the inbox screen atm, so please do not merge in this state.

As you can see, the title isn't actually large (until you scroll up) and there is some spacing between the nav bar and the segmented control. I think this was introduced somewhere when adding the tab bar?
![simulator screen shot - iphone x - 2017-10-11 at 15 40 13](https://user-images.githubusercontent.com/4190298/31443884-df749250-ae9a-11e7-8b76-04c15208e4f5.png)

Doesn't feel like it adds too much here.
![simulator screen shot - iphone x - 2017-10-11 at 15 40 15](https://user-images.githubusercontent.com/4190298/31443939-03738b84-ae9b-11e7-969d-dc0903f7ca5f.png)

I've left out a large title in the search tab, as there is no title there atm, just the search bar - which I think does enough on its own.