### PR TITLE
Adds sharing to code browsing

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2110</string>
+	<string>2116</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
If in the future we want to be able to share a URL to the code / open the code in Safari / etc., let's create separate tickets for that and add an actionsheet at that point. This also doesn't add support to share images and other files yet, but we can easily do so once we support showing those file types.

Fixes #589