### PR TITLE
Move some hardcoded "Search"es to Constants

### DIFF
--- a/Classes/Repository/RepositoryIssuesViewController.swift
+++ b/Classes/Repository/RepositoryIssuesViewController.swift
@@ -89,7 +89,7 @@ class RepositoryIssuesViewController: BaseListViewController<NSString>, BaseList
 
     func sectionController(model: Any, listAdapter: ListAdapter) -> ListSectionController {
         if let object = model as? ListDiffable, object === searchKey {
-            return SearchBarSectionController(placeholder: NSLocalizedString("Search", comment: ""), delegate: self)
+            return SearchBarSectionController(placeholder: Constants.Strings.search, delegate: self)
         }
         return RepositorySummarySectionController(client: client.githubClient, repo: repo)
     }

--- a/Classes/Search/SearchViewController.swift
+++ b/Classes/Search/SearchViewController.swift
@@ -60,7 +60,7 @@ SearchResultSectionControllerDelegate {
         adapter.dataSource = self
 
         searchBar.delegate = self
-        searchBar.placeholder = NSLocalizedString("Search", comment: "")
+        searchBar.placeholder = Constants.Strings.search
         searchBar.tintColor = Styles.Colors.Blue.medium.color
         searchBar.backgroundColor = .clear
         searchBar.searchBarStyle = .minimal

--- a/Classes/Systems/ShortcutHandler.swift
+++ b/Classes/Systems/ShortcutHandler.swift
@@ -10,9 +10,7 @@ import Foundation
 
 struct ShortcutHandler {
 
-    private struct Constants {
-        static let searchViewControllerIndex = 1
-    }
+    static private let searchViewControllerIndex = 1
 
     private enum Items: String {
         case search
@@ -29,7 +27,7 @@ struct ShortcutHandler {
         guard let itemType = Items(rawValue: item.type) else { return false }
         switch itemType {
         case .search:
-            navigationManager.selectViewController(atIndex: Constants.searchViewControllerIndex)
+            navigationManager.selectViewController(atIndex: searchViewControllerIndex)
             return true
         case .switchAccount:
             if let index = item.userInfo?["sessionIndex"] as? Int {
@@ -46,7 +44,7 @@ struct ShortcutHandler {
         // Search
         let searchIcon = UIApplicationShortcutIcon(templateImageName: "search")
         let searchItem = UIApplicationShortcutItem(type: Items.search.rawValue,
-                                                   localizedTitle: NSLocalizedString("Search", comment: ""),
+                                                   localizedTitle: Constants.Strings.search,
                                                    localizedSubtitle: nil,
                                                    icon: searchIcon,
                                                    userInfo: nil)

--- a/Classes/View Controllers/RootViewControllers.swift
+++ b/Classes/View Controllers/RootViewControllers.swift
@@ -44,7 +44,7 @@ func newNotificationsRootViewController(client: GithubClient) -> UIViewControlle
 func newSearchRootViewController(client: GithubClient) -> UIViewController {
     let controller = SearchViewController(client: client)
     let nav = UINavigationController(rootViewController: controller)
-    nav.tabBarItem.title = NSLocalizedString("Search", comment: "")
+    nav.tabBarItem.title = Constants.Strings.search
     nav.tabBarItem.image = UIImage(named: "tab-search")
     nav.tabBarItem.selectedImage = UIImage(named: "tab-search-selected")
     return nav


### PR DESCRIPTION
Removed the `ShortcutHandler.Constants` as it only had one constant anyway and it couldn't resolve `Constants.Strings.search`.