### PR TITLE
Fix: persist local changes

### DIFF
--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -330,7 +330,7 @@ IssueCommentSectionControllerDelegate {
     }
 
     func setStatus(close: Bool) {
-        guard let currentStatus = current?.status else { return }
+        guard let currentStatus = localStatusChange?.model ?? current?.status else { return }
 
         let localModel = IssueStatusModel(
             status: close ? .closed : .open,
@@ -366,7 +366,7 @@ IssueCommentSectionControllerDelegate {
     }
     
     func setLocked(_ locked: Bool) {
-        guard let currentStatus = current?.status else { return }
+        guard let currentStatus = localStatusChange?.model ?? current?.status else { return }
         
         let localModel = IssueStatusModel(
             status: currentStatus.status,

--- a/gql/API.swift
+++ b/gql/API.swift
@@ -3,7 +3,7 @@
 import Apollo
 
 /// Emojis that can be attached to Issues, Pull Requests and Comments.
-public enum ReactionContent: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
+public enum ReactionContent: String {
   /// Represents the 👍 emoji.
   case thumbsUp = "THUMBS_UP"
   /// Represents the 👎 emoji.
@@ -18,8 +18,10 @@ public enum ReactionContent: String, Apollo.JSONDecodable, Apollo.JSONEncodable 
   case heart = "HEART"
 }
 
+extension ReactionContent: Apollo.JSONDecodable, Apollo.JSONEncodable {}
+
 /// The possible states of a pull request review.
-public enum PullRequestReviewState: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
+public enum PullRequestReviewState: String {
   /// A review that has not yet been submitted.
   case pending = "PENDING"
   /// An informational review.
@@ -32,16 +34,20 @@ public enum PullRequestReviewState: String, Apollo.JSONDecodable, Apollo.JSONEnc
   case dismissed = "DISMISSED"
 }
 
+extension PullRequestReviewState: Apollo.JSONDecodable, Apollo.JSONEncodable {}
+
 /// The possible states of an issue.
-public enum IssueState: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
+public enum IssueState: String {
   /// An issue that is still open
   case `open` = "OPEN"
   /// An issue that has been closed
   case closed = "CLOSED"
 }
 
+extension IssueState: Apollo.JSONDecodable, Apollo.JSONEncodable {}
+
 /// The possible states of a pull request.
-public enum PullRequestState: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
+public enum PullRequestState: String {
   /// A pull request that is still open.
   case `open` = "OPEN"
   /// A pull request that has been closed without being merged.
@@ -49,6 +55,8 @@ public enum PullRequestState: String, Apollo.JSONDecodable, Apollo.JSONEncodable
   /// A pull request that has been closed by being merged.
   case merged = "MERGED"
 }
+
+extension PullRequestState: Apollo.JSONDecodable, Apollo.JSONEncodable {}
 
 public final class AddCommentMutation: GraphQLMutation {
   public static let operationString =

--- a/gql/API.swift
+++ b/gql/API.swift
@@ -3,7 +3,7 @@
 import Apollo
 
 /// Emojis that can be attached to Issues, Pull Requests and Comments.
-public enum ReactionContent: String {
+public enum ReactionContent: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
   /// Represents the 👍 emoji.
   case thumbsUp = "THUMBS_UP"
   /// Represents the 👎 emoji.
@@ -18,10 +18,8 @@ public enum ReactionContent: String {
   case heart = "HEART"
 }
 
-extension ReactionContent: Apollo.JSONDecodable, Apollo.JSONEncodable {}
-
 /// The possible states of a pull request review.
-public enum PullRequestReviewState: String {
+public enum PullRequestReviewState: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
   /// A review that has not yet been submitted.
   case pending = "PENDING"
   /// An informational review.
@@ -34,20 +32,16 @@ public enum PullRequestReviewState: String {
   case dismissed = "DISMISSED"
 }
 
-extension PullRequestReviewState: Apollo.JSONDecodable, Apollo.JSONEncodable {}
-
 /// The possible states of an issue.
-public enum IssueState: String {
+public enum IssueState: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
   /// An issue that is still open
   case `open` = "OPEN"
   /// An issue that has been closed
   case closed = "CLOSED"
 }
 
-extension IssueState: Apollo.JSONDecodable, Apollo.JSONEncodable {}
-
 /// The possible states of a pull request.
-public enum PullRequestState: String {
+public enum PullRequestState: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
   /// A pull request that is still open.
   case `open` = "OPEN"
   /// A pull request that has been closed without being merged.
@@ -55,8 +49,6 @@ public enum PullRequestState: String {
   /// A pull request that has been closed by being merged.
   case merged = "MERGED"
 }
-
-extension PullRequestState: Apollo.JSONDecodable, Apollo.JSONEncodable {}
 
 public final class AddCommentMutation: GraphQLMutation {
   public static let operationString =


### PR DESCRIPTION
Whenever on a PR/Issue, when you lock it, the lock badge appears, if afterwards you close the issue, the open badge changes to close and we lose the locked badge. 

This happens because every time there's a lock or status changed event, the local changes are reset to the fetched state, which is not ideal, the local changes should be cumulative.

Steps to reproduce:

1. Lock a PR
2. Close a PR (the lock badge will disappear)
3. Refresh PR (both the close and the lock badge appear)

This solves it.
