### PR TITLE
Add tap to dismiss keyboard in Notification ViewController

### DIFF
--- a/Classes/Notifications/NotificationsViewController.swift
+++ b/Classes/Notifications/NotificationsViewController.swift
@@ -59,6 +59,8 @@ TabNavRootViewControllerType {
         resetRightBarItem()
 
         navigationController?.tabBarItem.badgeColor = Styles.Colors.Red.medium.color
+
+        setupTapToDismissKeyboard()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -72,6 +74,16 @@ TabNavRootViewControllerType {
     }
 
     // MARK: Private API
+
+    func setupTapToDismissKeyboard() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(self.dismissKeyboard(_:)))
+
+        view.addGestureRecognizer(tap)
+    }
+
+    @objc func dismissKeyboard(_ sender: UIGestureRecognizer) {
+        view.endEditing(true)
+    }
 
     func resetRightBarItem() {
         navigationItem.rightBarButtonItem = UIBarButtonItem(

--- a/Classes/Notifications/NotificationsViewController.swift
+++ b/Classes/Notifications/NotificationsViewController.swift
@@ -77,7 +77,8 @@ TabNavRootViewControllerType {
 
     func setupTapToDismissKeyboard() {
         let tap = UITapGestureRecognizer(target: self, action: #selector(self.dismissKeyboard(_:)))
-
+        tap.cancelsTouchesInView = false
+        
         view.addGestureRecognizer(tap)
     }
 


### PR DESCRIPTION
I have added tap to dismiss keyboard in the keyboard. Right now you have to drag to dismiss it. 😄 