### PR TITLE
Cancelled debounce action if explicit search

### DIFF
--- a/Classes/Search/SearchViewController.swift
+++ b/Classes/Search/SearchViewController.swift
@@ -202,6 +202,7 @@ SearchResultSectionControllerDelegate {
 
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         searchBar.resignFirstResponder()
+        debouncer.cancel()
 
         guard let term = searchTerm(for: searchBar.text) else { return }
         search(term: term)

--- a/Classes/Systems/Debouncer.swift
+++ b/Classes/Systems/Debouncer.swift
@@ -27,6 +27,10 @@ class Debouncer {
         self.action = action
     }
 
+    func cancel() {
+        timer?.invalidate()
+    }
+
     private func debounce() {
         timer?.invalidate()
         timer = Timer.scheduledTimer(


### PR DESCRIPTION
Closes #638

Classic race condition.

Apollo `FetchQueryOperation` is a class. 
Auto-search while typing is queuing up tasks to be fired after so many milliseconds. If the user hits enter to explicitly trigger a search during that time, we immediately start executing the search. In the mean-time, the debounced signal from the type-while-search fires, notices we're in a loading state and ends up cancelling the explicitly placed search. _because_ apollo queries are classes, and it's making the same network call, it ends up cancelling its own operation.