### PR TITLE
Added insets handling for SearchViewController

### DIFF
--- a/Classes/Search/SearchViewController.swift
+++ b/Classes/Search/SearchViewController.swift
@@ -73,6 +73,20 @@ SearchResultSectionControllerDelegate {
         searchBar.backgroundColor = .clear
         searchBar.searchBarStyle = .minimal
         navigationItem.titleView = searchBar
+
+        let nc = NotificationCenter.default
+        nc.addObserver(
+            self,
+            selector: #selector(onKeyboardWillShow(notification:)),
+            name: .UIKeyboardWillShow,
+            object: nil
+        )
+        nc.addObserver(
+            self,
+            selector: #selector(onKeyboardWillHide(notification:)),
+            name: .UIKeyboardWillHide,
+            object: nil
+        )
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -88,6 +102,24 @@ SearchResultSectionControllerDelegate {
             collectionView.frame = bounds
             collectionView.collectionViewLayout.invalidateLayout()
         }
+    }
+    // MARK: Notifications
+
+    @objc
+    func onKeyboardWillShow(notification: NSNotification) {
+        guard let frame = notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? CGRect else { return }
+        let converted = view.convert(frame, from: nil)
+        let intersection = converted.intersection(frame)
+        let bottomInset = intersection.height - bottomLayoutGuide.length
+        let inset = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
+        collectionView.contentInset = inset
+        collectionView.scrollIndicatorInsets = inset
+    }
+
+    @objc
+    func onKeyboardWillHide(notification: NSNotification) {
+        collectionView.contentInset = .zero
+        collectionView.scrollIndicatorInsets = .zero
     }
 
     // MARK: Data Loading/Paging


### PR DESCRIPTION
Hi!
This PR adds keyboard handling so users will be able to scroll to the bottom of the list when keyboard is on the screen. Like here: 
<img width="887" alt="screen shot 2017-10-22 at 20 18 41" src="https://user-images.githubusercontent.com/4790464/31864448-35357e10-b766-11e7-8940-749c19449926.png">
