### PR TITLE
Settings view source redirects to Repository view Code Tab

### DIFF
--- a/Classes/Repository/RepositoryViewController.swift
+++ b/Classes/Repository/RepositoryViewController.swift
@@ -12,6 +12,13 @@ import Pageboy
 import TUSafariActivity
 import SafariServices
 
+enum RepositoryPageIndex: Int {
+    case overview    = 0
+    case issues      = 1
+    case pullRequest = 2
+    case code        = 3
+}
+
 class RepositoryViewController: TabmanViewController,
 PageboyViewControllerDataSource,
 NewIssueTableViewControllerDelegate {
@@ -19,11 +26,13 @@ NewIssueTableViewControllerDelegate {
     private let repo: RepositoryDetails
     private let client: GithubClient
     private let controllers: [UIViewController]
+    private let defaultPageIndex: RepositoryPageIndex
 
-    init(client: GithubClient, repo: RepositoryDetails) {
+    init(client: GithubClient, repo: RepositoryDetails, defaultPageIndex:RepositoryPageIndex = .overview) {
         self.repo = repo
         self.client = client
-
+        self.defaultPageIndex = defaultPageIndex
+        
         var controllers: [UIViewController] = [RepositoryOverviewViewController(client: client, repo: repo)]
         if repo.hasIssuesEnabled {
             controllers.append(RepositoryIssuesViewController(client: client, repo: repo, type: .issues))
@@ -142,7 +151,7 @@ NewIssueTableViewControllerDelegate {
     }
 
     func defaultPage(for pageboyViewController: PageboyViewController) -> PageboyViewController.Page? {
-        return nil
+        return Page.at(index: defaultPageIndex.rawValue)
     }
 
     // MARK: NewIssueTableViewControllerDelegate

--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -116,9 +116,14 @@ NewIssueTableViewControllerDelegate {
     }
 
     func onViewSource() {
-        guard let url = URL(string: Constants.URLs.repository)
-            else { fatalError("Should always create GitHub URL") }
-		presentSafari(url: url)
+        let repo = RepositoryDetails(
+            owner: "rnystrom",
+            name: "GitHawk",
+            hasIssuesEnabled: true
+        )
+        let repoViewController = RepositoryViewController(client: client, repo: repo, defaultPageIndex: .code)
+        let navigation = UINavigationController(rootViewController: repoViewController)
+        showDetailViewController(navigation, sender: nil)
     }
 
     func onSignOut() {

--- a/Classes/View Controllers/RootViewControllers.swift
+++ b/Classes/View Controllers/RootViewControllers.swift
@@ -21,6 +21,7 @@ func newSettingsRootViewController(
         first.client = client
         first.sessionManager = sessionManager
         first.rootNavigationManager = rootNavigationManager
+        first.makeBackBarItemEmpty()
         nav.tabBarItem.title = NSLocalizedString("Settings", comment: "")
         nav.tabBarItem.image = UIImage(named: "tab-gear")
         nav.tabBarItem.selectedImage = UIImage(named: "tab-gear-selected")


### PR DESCRIPTION
Since we do have code browsing, It's nice to redirect our settings "view source" button to repository view code tab. In case user still wants to see repo in safari, they can use more button on top right in repo screen.
