### PR TITLE
Unified deletion swipes

### DIFF
--- a/Classes/Bookmark/BookmarksViewController.swift
+++ b/Classes/Bookmark/BookmarksViewController.swift
@@ -83,6 +83,7 @@ TabNavRootViewControllerType {
         alert.addActions([
             AlertAction.clearAll({ [weak self] _ in
                 self?.bookmarkStore.clear()
+                self?.filteredBookmarks?.removeAll()
                 self?.tableView.reloadData()
                 self?.updateRightBarItem()
             }),
@@ -203,6 +204,7 @@ TabNavRootViewControllerType {
         let action = DeleteSwipeAction { [weak self] _, index in
             guard let strongSelf = self else { return }
             strongSelf.bookmarkStore.remove(bookmark: strongSelf.bookmarks[index.row])
+            strongSelf.updateRightBarItem()
         }
 
         return [action]

--- a/Classes/Bookmark/BookmarksViewController.swift
+++ b/Classes/Bookmark/BookmarksViewController.swift
@@ -27,6 +27,8 @@ TabNavRootViewControllerType {
         controller.searchBar.backgroundColor = .clear
         controller.searchBar.searchBarStyle = .minimal
         return controller
+    }
+    
     private var filteredBookmarks: [BookmarkModel]?
 
     private var isSearchActive: Bool {

--- a/Classes/Bookmark/BookmarksViewController.swift
+++ b/Classes/Bookmark/BookmarksViewController.swift
@@ -200,15 +200,10 @@ TabNavRootViewControllerType {
     func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> [SwipeAction]? {
         guard orientation == .right, !isSearchActive else { return nil }
 
-        let action = SwipeAction(style: .destructive, title: "Delete") { [weak self] _, index in
+        let action = DeleteSwipeAction { [weak self] _, index in
             guard let strongSelf = self else { return }
             strongSelf.bookmarkStore.remove(bookmark: strongSelf.bookmarks[index.row])
         }
-
-        action.image = #imageLiteral(resourceName: "trashcan").withRenderingMode(.alwaysTemplate)
-        action.backgroundColor = Styles.Colors.Red.medium.color
-        action.textColor = .white
-        action.tintColor = .white
 
         return [action]
     }

--- a/Classes/Bookmark/BookmarksViewController.swift
+++ b/Classes/Bookmark/BookmarksViewController.swift
@@ -235,8 +235,7 @@ TabNavRootViewControllerType {
     }
 
     private func configure(cell: SwipeSelectableTableCell, with bookmark: BookmarkModel) {
-        let titleLabel = "\(bookmark.owner)/\(bookmark.name)"
-        cell.textLabel?.text = bookmark.type == .repo ? titleLabel : titleLabel + " #\(bookmark.number)"
+        cell.textLabel?.attributedText = titleLabel(for: bookmark)
         cell.detailTextLabel?.text = bookmark.title
         cell.textLabel?.numberOfLines = 0
         cell.detailTextLabel?.numberOfLines = 0
@@ -250,5 +249,21 @@ TabNavRootViewControllerType {
         cell.imageView?.tintColor = Styles.Colors.Blue.medium.color
 
         cell.delegate = self
+    }
+
+    private func titleLabel(for bookmark: BookmarkModel) -> NSAttributedString {
+        let repositoryText = NSMutableAttributedString(attributedString: RepositoryAttributedString(owner: bookmark.owner, name: bookmark.name))
+        switch bookmark.type {
+        case .issue, .pullRequest:
+            let bookmarkText = NSAttributedString(string: "#\(bookmark.number)", attributes: [
+                .font: Styles.Fonts.body,
+                .foregroundColor: Styles.Colors.Gray.dark.color
+                ]
+            )
+            repositoryText.append(bookmarkText)
+        default:
+            break
+        }
+        return repositoryText
     }
 }

--- a/Classes/Search/SearchRecentSectionController.swift
+++ b/Classes/Search/SearchRecentSectionController.swift
@@ -63,7 +63,7 @@ final class SearchRecentSectionController: ListGenericSectionController<SearchRe
 
     func collectionView(_ collectionView: UICollectionView, editActionsOptionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> SwipeTableOptions {
         var options = SwipeTableOptions()
-        options.expansionStyle = .selection
+        options.expansionStyle = .destructive
         return options
     }
 

--- a/Classes/Search/SearchRecentSectionController.swift
+++ b/Classes/Search/SearchRecentSectionController.swift
@@ -49,14 +49,10 @@ final class SearchRecentSectionController: ListGenericSectionController<SearchRe
     func collectionView(_ collectionView: UICollectionView, editActionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> [SwipeAction]? {
         guard orientation == .right else { return nil }
 
-        let action = SwipeAction(style: .destructive, title: Constants.Strings.delete) { [weak self] _, _ in
+        let action = DeleteSwipeAction { [weak self] _, _ in
             guard let strongSelf = self, let object = strongSelf.object else { return }
             strongSelf.delegate?.didDelete(recentSectionController: strongSelf, viewModel: object)
         }
-        action.image = #imageLiteral(resourceName: "trashcan").withRenderingMode(.alwaysTemplate)
-        action.backgroundColor = Styles.Colors.Red.medium.color
-        action.textColor = .white
-        action.tintColor = .white
 
         return [action]
     }

--- a/Classes/Search/SearchRecentViewModel.swift
+++ b/Classes/Search/SearchRecentViewModel.swift
@@ -27,9 +27,7 @@ final class SearchRecentViewModel: NSObject, ListDiffable {
         case .search(let text):
             return NSAttributedString(string: text, attributes: standardAttributes)
         case .recentlyViewed(let repoDetails):
-            let text = NSMutableAttributedString(string: repoDetails.owner + "/", attributes: standardAttributes)
-            text.append(NSAttributedString(string: repoDetails.name, attributes: boldAttributes))
-            return text
+            return RepositoryAttributedString(owner: repoDetails.owner, name: repoDetails.name)
         }
     }
 
@@ -64,13 +62,6 @@ final class SearchRecentViewModel: NSObject, ListDiffable {
     private var standardAttributes: [NSAttributedStringKey: Any] {
         return [
             .font: Styles.Fonts.body,
-            .foregroundColor: Styles.Colors.Gray.dark.color
-        ]
-    }
-
-    private var boldAttributes: [NSAttributedStringKey: Any] {
-        return [
-            .font: Styles.Fonts.bodyBold,
             .foregroundColor: Styles.Colors.Gray.dark.color
         ]
     }

--- a/Classes/Search/SearchRepoResultCell.swift
+++ b/Classes/Search/SearchRepoResultCell.swift
@@ -88,17 +88,7 @@ final class SearchRepoResultCell: SelectableCell {
     }
 
     func configure(result: SearchRepoResult) {
-        let ownerAttributes = [
-            NSAttributedStringKey.font: Styles.Fonts.body,
-            NSAttributedStringKey.foregroundColor: Styles.Colors.Gray.dark.color
-        ]
-        let title = NSMutableAttributedString(string: result.owner + "/", attributes: ownerAttributes)
-        let nameAttributes = [
-            NSAttributedStringKey.font: Styles.Fonts.bodyBold,
-            NSAttributedStringKey.foregroundColor: Styles.Colors.Gray.dark.color
-        ]
-        title.append(NSAttributedString(string: result.name, attributes: nameAttributes))
-        titleLabel.attributedText = title
+        titleLabel.attributedText = RepositoryAttributedString(owner: result.owner, name: result.name)
 
         descriptionLabel.text = result.description
 

--- a/Classes/Utility/DeleteSwipeAction.swift
+++ b/Classes/Utility/DeleteSwipeAction.swift
@@ -1,0 +1,20 @@
+//
+//  DeleteSwipeAction.swift
+//  Freetime
+//
+//  Created by Hesham Salman on 10/24/17.
+//  Copyright © 2017 Ryan Nystrom. All rights reserved.
+//
+
+import SwipeCellKit
+
+func DeleteSwipeAction(callback: ((SwipeAction, IndexPath) -> Void)? = nil) -> SwipeAction {
+    let action = SwipeAction(style: .destructive, title: Constants.Strings.delete, handler: callback)
+
+    action.image = #imageLiteral(resourceName: "trashcan").withRenderingMode(.alwaysTemplate)
+    action.backgroundColor = Styles.Colors.Red.medium.color
+    action.textColor = .white
+    action.tintColor = .white
+
+    return action
+}

--- a/Classes/Utility/RepositoryAttributedString.swift
+++ b/Classes/Utility/RepositoryAttributedString.swift
@@ -9,21 +9,17 @@
 import Foundation
 
 func RepositoryAttributedString(owner: String, name: String) -> NSAttributedString {
-    let text = NSMutableAttributedString(string: owner + "/", attributes: ownerAttributes)
-    text.append(NSAttributedString(string: name, attributes: nameAttributes))
-    return text
-}
-
-private var ownerAttributes: [NSAttributedStringKey: Any] {
-    return [
+    let ownerAttributes: [NSAttributedStringKey: Any] = [
         .font: Styles.Fonts.body,
         .foregroundColor: Styles.Colors.Gray.dark.color
     ]
-}
 
-private var nameAttributes: [NSAttributedStringKey: Any] {
-    return [
+    let nameAttributes: [NSAttributedStringKey: Any] = [
         .font: Styles.Fonts.bodyBold,
         .foregroundColor: Styles.Colors.Gray.dark.color
     ]
+
+    let text = NSMutableAttributedString(string: owner + "/", attributes: ownerAttributes)
+    text.append(NSAttributedString(string: name, attributes: nameAttributes))
+    return text
 }

--- a/Classes/Utility/RepositoryAttributedString.swift
+++ b/Classes/Utility/RepositoryAttributedString.swift
@@ -1,0 +1,29 @@
+//
+//  RepositoryAttributedString.swift
+//  Freetime
+//
+//  Created by Hesham Salman on 10/24/17.
+//  Copyright © 2017 Ryan Nystrom. All rights reserved.
+//
+
+import Foundation
+
+func RepositoryAttributedString(owner: String, name: String) -> NSAttributedString {
+    let text = NSMutableAttributedString(string: owner + "/", attributes: ownerAttributes)
+    text.append(NSAttributedString(string: name, attributes: nameAttributes))
+    return text
+}
+
+private var ownerAttributes: [NSAttributedStringKey: Any] {
+    return [
+        .font: Styles.Fonts.body,
+        .foregroundColor: Styles.Colors.Gray.dark.color
+    ]
+}
+
+private var nameAttributes: [NSAttributedStringKey: Any] {
+    return [
+        .font: Styles.Fonts.bodyBold,
+        .foregroundColor: Styles.Colors.Gray.dark.color
+    ]
+}

--- a/Classes/Views/SelectableCell.swift
+++ b/Classes/Views/SelectableCell.swift
@@ -114,3 +114,33 @@ class SwipeSelectableCell: SwipeCollectionViewCell {
     }
 
 }
+
+class SwipeSelectableTableCell: SwipeTableViewCell {
+
+    private lazy var overlay: UIView = {
+        return self.contentView.addOverlay()
+    }()
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        overlay.prepareOverlayForReuse()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layoutContentViewForSafeAreaInsets()
+        overlay.layoutOverlay()
+    }
+
+    override var isSelected: Bool {
+        didSet {
+            overlay.showOverlay(show: isSelected)
+        }
+    }
+
+    override var isHighlighted: Bool {
+        didSet {
+            overlay.showOverlay(show: isHighlighted)
+        }
+    }
+}

--- a/Classes/Views/UICollectionViewCell+SafeAreaContentView.swift
+++ b/Classes/Views/UICollectionViewCell+SafeAreaContentView.swift
@@ -26,3 +26,20 @@ extension UICollectionViewCell {
     }
 
 }
+
+extension UITableViewCell {
+    func layoutContentViewForSafeAreaInsets() {
+        let insets: UIEdgeInsets
+        if #available(iOS 11.0, *) {
+            insets = safeAreaInsets
+        } else {
+            insets = .zero
+        }
+        contentView.frame = CGRect(
+            x: insets.left,
+            y: bounds.minY,
+            width: bounds.width - insets.left - insets.right,
+            height: bounds.height
+        )
+    }
+}

--- a/Classes/Views/UITableViewCell+SafeAreaContentView.swift
+++ b/Classes/Views/UITableViewCell+SafeAreaContentView.swift
@@ -1,15 +1,14 @@
 //
-//  UICollectionViewCell+SafeAreaContentView.swift
+//  UITableViewCell+SafeAreaContentView.swift
 //  Freetime
 //
-//  Created by Ryan Nystrom on 10/16/17.
+//  Created by Hesham Salman on 10/24/17.
 //  Copyright © 2017 Ryan Nystrom. All rights reserved.
 //
 
 import UIKit
 
-extension UICollectionViewCell {
-
+extension UITableViewCell {
     func layoutContentViewForSafeAreaInsets() {
         let insets: UIEdgeInsets
         if #available(iOS 11.0, *) {
@@ -24,5 +23,4 @@ extension UICollectionViewCell {
             height: bounds.height
         )
     }
-
 }

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -391,6 +391,7 @@
 		DC60C6DC1F99414E00241271 /* IsCancellationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC60C6DB1F99414E00241271 /* IsCancellationError.swift */; };
 		DC6339371F9F567000402A8D /* DeleteSwipeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6339361F9F567000402A8D /* DeleteSwipeAction.swift */; };
 		DC6339391F9F5ACB00402A8D /* UITableViewCell+SafeAreaContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6339381F9F5ACB00402A8D /* UITableViewCell+SafeAreaContentView.swift */; };
+		DC63393B1F9F65EE00402A8D /* RepositoryAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC63393A1F9F65EE00402A8D /* RepositoryAttributedString.swift */; };
 		DC7857101F97F546009BADDA /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC78570F1F97F546009BADDA /* Debouncer.swift */; };
 /* End PBXBuildFile section */
 
@@ -766,6 +767,7 @@
 		DC60C6DB1F99414E00241271 /* IsCancellationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsCancellationError.swift; sourceTree = "<group>"; };
 		DC6339361F9F567000402A8D /* DeleteSwipeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteSwipeAction.swift; sourceTree = "<group>"; };
 		DC6339381F9F5ACB00402A8D /* UITableViewCell+SafeAreaContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+SafeAreaContentView.swift"; sourceTree = "<group>"; };
+		DC63393A1F9F65EE00402A8D /* RepositoryAttributedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryAttributedString.swift; sourceTree = "<group>"; };
 		DC78570F1F97F546009BADDA /* Debouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
 		EA08BE0B8263E4898B1DF86B /* Pods-Freetime.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Freetime.release.xcconfig"; path = "Pods/Target Support Files/Pods-Freetime/Pods-Freetime.release.xcconfig"; sourceTree = "<group>"; };
 		F2F33C5360D6CF79F44FFF42 /* Pods_FreetimeTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FreetimeTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1613,6 +1615,7 @@
 				DC60C6DB1F99414E00241271 /* IsCancellationError.swift */,
 				49FFF4331F9FC83200335568 /* HapticFeedback.swift */,
 				DC6339361F9F567000402A8D /* DeleteSwipeAction.swift */,
+				DC63393A1F9F65EE00402A8D /* RepositoryAttributedString.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -2168,6 +2171,7 @@
 				29C53FC31F12EF4000A59ED5 /* IssueReferencedModel.swift in Sources */,
 				29C53FC41F12EF4000A59ED5 /* IssueReferencedSectionController.swift in Sources */,
 				2928C78A1F15D7E00000D06D /* IssueRenamedCell.swift in Sources */,
+				DC63393B1F9F65EE00402A8D /* RepositoryAttributedString.swift in Sources */,
 				2928C7881F15D7C50000D06D /* IssueRenamedModel.swift in Sources */,
 				2928C78C1F15D80E0000D06D /* IssueRenamedSectionController.swift in Sources */,
 				2928C78E1F15DF1B0000D06D /* IssueRenamedString.swift in Sources */,

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -389,6 +389,8 @@
 		DC60C6D31F983BB900241271 /* SignatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC60C6D21F983BB900241271 /* SignatureTests.swift */; };
 		DC60C6D51F983DF800241271 /* IssueLabelCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC60C6D41F983DF800241271 /* IssueLabelCellTests.swift */; };
 		DC60C6DC1F99414E00241271 /* IsCancellationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC60C6DB1F99414E00241271 /* IsCancellationError.swift */; };
+		DC6339371F9F567000402A8D /* DeleteSwipeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6339361F9F567000402A8D /* DeleteSwipeAction.swift */; };
+		DC6339391F9F5ACB00402A8D /* UITableViewCell+SafeAreaContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6339381F9F5ACB00402A8D /* UITableViewCell+SafeAreaContentView.swift */; };
 		DC7857101F97F546009BADDA /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC78570F1F97F546009BADDA /* Debouncer.swift */; };
 /* End PBXBuildFile section */
 
@@ -762,6 +764,8 @@
 		DC60C6D21F983BB900241271 /* SignatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignatureTests.swift; sourceTree = "<group>"; };
 		DC60C6D41F983DF800241271 /* IssueLabelCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueLabelCellTests.swift; sourceTree = "<group>"; };
 		DC60C6DB1F99414E00241271 /* IsCancellationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsCancellationError.swift; sourceTree = "<group>"; };
+		DC6339361F9F567000402A8D /* DeleteSwipeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteSwipeAction.swift; sourceTree = "<group>"; };
+		DC6339381F9F5ACB00402A8D /* UITableViewCell+SafeAreaContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+SafeAreaContentView.swift"; sourceTree = "<group>"; };
 		DC78570F1F97F546009BADDA /* Debouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
 		EA08BE0B8263E4898B1DF86B /* Pods-Freetime.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Freetime.release.xcconfig"; path = "Pods/Target Support Files/Pods-Freetime/Pods-Freetime.release.xcconfig"; sourceTree = "<group>"; };
 		F2F33C5360D6CF79F44FFF42 /* Pods_FreetimeTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FreetimeTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1386,6 +1390,7 @@
 				29AF1E891F8AB1C30008A0EF /* TextActionsController.swift */,
 				2982ED791F94EA8F00DBF8EB /* UICollectionViewCell+SafeAreaContentView.swift */,
 				D8C2AEF41F9AA94600A95945 /* DotListView.swift */,
+				DC6339381F9F5ACB00402A8D /* UITableViewCell+SafeAreaContentView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1607,6 +1612,7 @@
 				98B5A0851F6D0FFE000617D6 /* UINavigationController+Replace.swift */,
 				DC60C6DB1F99414E00241271 /* IsCancellationError.swift */,
 				49FFF4331F9FC83200335568 /* HapticFeedback.swift */,
+				DC6339361F9F567000402A8D /* DeleteSwipeAction.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -2195,6 +2201,7 @@
 				2919294B1F3EAD890012067B /* IssueViewFilesCell.swift in Sources */,
 				291929491F3EAD2E0012067B /* IssueViewFilesSectionController.swift in Sources */,
 				292FCB101EDFCC510026635E /* IssueViewModels.swift in Sources */,
+				DC6339391F9F5ACB00402A8D /* UITableViewCell+SafeAreaContentView.swift in Sources */,
 				2963A93B1EE25F6F0066509C /* LabelableFields+IssueLabelModel.swift in Sources */,
 				98835BD21F1A158D005BA24F /* LabelCell.swift in Sources */,
 				29EE1C1B1F3A33000046A54D /* LabelsViewController.swift in Sources */,
@@ -2293,6 +2300,7 @@
 				29EE444A1F19D85800B05ED3 /* ShowErrorStatusBar.swift in Sources */,
 				295840711EE9F4D3007723C6 /* ShowMoreDetailsLabel+Date.swift in Sources */,
 				29C295111EC7B83200D46CD2 /* ShowMoreDetailsLabel.swift in Sources */,
+				DC6339371F9F567000402A8D /* DeleteSwipeAction.swift in Sources */,
 				29973E561F68BFDE0004B693 /* Signature.swift in Sources */,
 				2971722D1F069E96005E43AC /* SpinnerCell.swift in Sources */,
 				2930F2731F8A27750082BA26 /* WidthCache.swift in Sources */,

--- a/Local Pods/SwipeCellKit/Source/Extensions.swift
+++ b/Local Pods/SwipeCellKit/Source/Extensions.swift
@@ -18,8 +18,16 @@ extension UITableView {
     
     func setGestureEnabled(_ enabled: Bool) {
         gestureRecognizers?.forEach {
-            guard $0 != panGestureRecognizer else { return }
-            
+            guard $0 != panGestureRecognizer else {
+                return
+            }
+
+            guard let recognizer = NSClassFromString("UISwipeDismissalGestureRecognizer"), !$0.isKind(of: recognizer) else {
+                // Always be false or you can not trigger swipe action's callback
+                $0.isEnabled = false
+                return
+            }
+
             $0.isEnabled = enabled
         }
     }
@@ -36,7 +44,15 @@ extension UICollectionView {
 
     func setGestureEnabled(_ enabled: Bool) {
         gestureRecognizers?.forEach {
-            guard $0 != panGestureRecognizer else { return }
+            guard $0 != panGestureRecognizer else {
+                return
+            }
+
+            guard let recognizer = NSClassFromString("UISwipeDismissalGestureRecognizer"), !$0.isKind(of: recognizer) else {
+                // Always be false or you can not trigger swipe action's callback
+                $0.isEnabled = false
+                return
+            }
 
             $0.isEnabled = enabled
         }


### PR DESCRIPTION
- Pulled workaround for iOS 11 & UITableViewCells from SwipeCellKit (https://github.com/SwipeCellKit/SwipeCellKit/issues/48)  (ref #679 ?)
- Made destructive swipe behavior generic
- Changed destructive swipe animation
- Matched search and bookmark cell heights
- Rolled in changes from #717 and #698 

![2017-10-24 08_23_52](https://user-images.githubusercontent.com/3388381/31942868-c8ece9f2-b894-11e7-98b0-421be921a4e6.gif)

Closes #709 #710 #705 #659
