### PR TITLE
Fixes bookmark search behaviours 

### DIFF
--- a/Classes/Bookmark/BookmarksViewController.swift
+++ b/Classes/Bookmark/BookmarksViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import SwipeCellKit
 
 class BookmarksViewController: UITableViewController,
-    UISearchBarDelegate,
+    UISearchResultsUpdating,
     PrimaryViewController,
     SwipeTableViewCellDelegate,
 TabNavRootViewControllerType {
@@ -19,15 +19,7 @@ TabNavRootViewControllerType {
     private let cellIdentifier = "bookmark_cell"
     private let bookmarkStore = BookmarksStore.shared
 
-    private var searchController: UISearchController {
-        let controller = UISearchController(searchResultsController: nil)
-        controller.searchBar.delegate = self
-        controller.searchBar.placeholder = NSLocalizedString(Constants.Strings.search, comment: "")
-        controller.searchBar.tintColor = Styles.Colors.Blue.medium.color
-        controller.searchBar.backgroundColor = .clear
-        controller.searchBar.searchBarStyle = .minimal
-        return controller
-    }
+    private var searchController: UISearchController = UISearchController(searchResultsController:nil)
     
     private var filteredBookmarks: [BookmarkModel]?
 
@@ -171,31 +163,12 @@ TabNavRootViewControllerType {
         showDetailViewController(navigation, sender: nil)
     }
 
-    // MARK: UISearchBarDelegate
+    // MARK: UISearchResultsUpdating
+    
+    func updateSearchResults(for searchController: UISearchController) {
+        guard let term = searchController.searchBar.text?.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
 
-    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        guard let term = searchBar.text?.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
-
-        filter(query: term)
-    }
-
-    func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
-        searchBar.setShowsCancelButton(true, animated: true)
-    }
-
-    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-        searchBar.resignFirstResponder()
-        guard let term = searchBar.text?.trimmingCharacters(in: .whitespacesAndNewlines),
-            !term.isEmpty else { return }
-
-        filter(query: term)
-    }
-
-    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
-        searchBar.setShowsCancelButton(false, animated: true)
-        searchBar.text = ""
-        searchBar.resignFirstResponder()
-        filter(query: nil)
+        filter(query: !term.isEmpty ? term : nil)
     }
 
     // MARK: - SwipeTableViewCellDelegate
@@ -221,6 +194,16 @@ TabNavRootViewControllerType {
     // MARK: - Private API
 
     private func configureSearchBar() {
+
+        searchController.searchBar.placeholder = NSLocalizedString(Constants.Strings.search, comment: "")
+        searchController.searchBar.tintColor = Styles.Colors.Blue.medium.color
+        searchController.searchBar.backgroundColor = .clear
+        searchController.searchBar.searchBarStyle = .minimal
+        searchController.searchBar.sizeToFit()
+        searchController.obscuresBackgroundDuringPresentation = false
+        searchController.searchResultsUpdater = self
+        definesPresentationContext = true
+       
         if #available(iOS 11.0, *) {
             navigationController?.navigationBar.prefersLargeTitles = true
             navigationItem.searchController = searchController

--- a/Classes/Bookmark/BookmarksViewController.swift
+++ b/Classes/Bookmark/BookmarksViewController.swift
@@ -207,7 +207,6 @@ TabNavRootViewControllerType {
         if #available(iOS 11.0, *) {
             navigationController?.navigationBar.prefersLargeTitles = true
             navigationItem.searchController = searchController
-            navigationItem.hidesSearchBarWhenScrolling = false
         } else {
             tableView.tableHeaderView = searchController.searchBar
         }


### PR DESCRIPTION
Closes #728 

Bonus feature from #692 - hides the search bar under the navigation bar for iOS 11. So that for smaller devices it will give some room for contents

Update:
Tested on iOS 10, 10.2 and 11