### PR TITLE
Adds keyboard dismiss on new issue cancel

### DIFF
--- a/Classes/New Issue/NewIssueTableViewController.swift
+++ b/Classes/New Issue/NewIssueTableViewController.swift
@@ -160,6 +160,8 @@ final class NewIssueTableViewController: UITableViewController, UITextFieldDeleg
     /// Ensures there are no unsaved changes before dismissing the view controller. Will prompt user if unsaved changes.
     @objc
     func onCancel() {
+        titleField.resignFirstResponder()
+        bodyField.resignFirstResponder()
         cancelAction_onCancel(
             texts: [titleText, bodyText],
             title: NSLocalizedString("Unsaved Changes", comment: "New Issue - Cancel w/ Unsaved Changes Title"),


### PR DESCRIPTION
When pressing cancel on the new issue vc the keyboard sticks around a bit after the vc has dismissed.

![2017-10-25 17_13_13](https://user-images.githubusercontent.com/10346184/32023629-d65cc738-b9a7-11e7-9f36-4b93b59fc719.gif)

This dismisses keyboard simultaneously.