### PR TITLE
Ignore invert colors for profile images + image uploads

### DIFF
--- a/Classes/Image Upload/ImageUploadTableViewController.swift
+++ b/Classes/Image Upload/ImageUploadTableViewController.swift
@@ -14,7 +14,12 @@ protocol ImageUploadDelegate: class {
 
 class ImageUploadTableViewController: UITableViewController, UITextFieldDelegate {
 
-    @IBOutlet private var previewImageView: UIImageView!
+    @IBOutlet private var previewImageView: UIImageView! {
+        didSet {
+            guard #available(iOS 11, *) else { return }
+            previewImageView.accessibilityIgnoresInvertColors = true
+        }
+    }
     @IBOutlet private var titleTextField: UITextField!
     @IBOutlet private var bodyTextField: UITextView!
 

--- a/Classes/Issues/Assignees/IssueAssigneeAvatarCell.swift
+++ b/Classes/Issues/Assignees/IssueAssigneeAvatarCell.swift
@@ -21,6 +21,9 @@ final class IssueAssigneeAvatarCell: UICollectionViewCell {
         imageView.layer.borderColor = Styles.Colors.Gray.light.color.cgColor
         imageView.layer.borderWidth = 1.0 / UIScreen.main.scale
         imageView.clipsToBounds = true
+        if #available(iOS 11, *) {
+            imageView.accessibilityIgnoresInvertColors = true
+        }
         contentView.addSubview(imageView)
     }
 

--- a/Classes/Issues/Assignees/IssueAssigneeUserCell.swift
+++ b/Classes/Issues/Assignees/IssueAssigneeUserCell.swift
@@ -24,6 +24,9 @@ final class IssueAssigneeUserCell: UICollectionViewCell, ListBindable {
         imageView.layer.borderColor = Styles.Colors.Gray.light.color.cgColor
         imageView.layer.borderWidth = 1.0 / UIScreen.main.scale
         imageView.clipsToBounds = true
+        if #available(iOS 11, *) {
+            imageView.accessibilityIgnoresInvertColors = true
+        }
         contentView.addSubview(imageView)
         imageView.snp.makeConstraints { make in
             make.centerY.equalTo(contentView)

--- a/Classes/Issues/Commit/IssueCommitCell.swift
+++ b/Classes/Issues/Commit/IssueCommitCell.swift
@@ -45,6 +45,9 @@ final class IssueCommitCell: UICollectionViewCell {
             target: self,
             action: #selector(IssueCommitCell.onAvatar))
         )
+        if #available(iOS 11, *) {
+            avatarImageView.accessibilityIgnoresInvertColors = true
+        }
         contentView.addSubview(avatarImageView)
         avatarImageView.snp.makeConstraints { make in
             make.centerY.equalTo(contentView)


### PR DESCRIPTION
Can't test it on the simulator because you can't enable inverted colors there as far as I can tell. Super lame.

Ref #118 