### PR TITLE
Update Bookmark quick action title

### DIFF
--- a/Classes/Systems/ShortcutHandler.swift
+++ b/Classes/Systems/ShortcutHandler.swift
@@ -57,7 +57,7 @@ struct ShortcutHandler {
         // Bookmarks
         let bookmarkIcon = UIApplicationShortcutIcon(templateImageName: "bookmarks")
         let bookmarkItem = UIApplicationShortcutItem(type: Items.bookmarks.rawValue,
-                                                   localizedTitle: Constants.Strings.bookmark,
+                                                   localizedTitle: Constants.Strings.bookmarks,
                                                    localizedSubtitle: nil,
                                                    icon: bookmarkIcon)
         items.append(bookmarkItem)


### PR DESCRIPTION
Fixes https://github.com/rnystrom/GitHawk/issues/754

- Updates the Bookmark quick action title to the plural `"Bookmarks"` vs `"Bookmark"` 

### Before

![simulator screen shot - iphone 8 - 2017-10-26 at 17 44 15](https://user-images.githubusercontent.com/3321592/32078741-1476e944-ba76-11e7-9b13-16cc4977f9e3.png)


### After
![simulator screen shot - iphone 8 - 2017-10-26 at 17 46 30](https://user-images.githubusercontent.com/3321592/32078742-14849508-ba76-11e7-895f-42ec6315fda1.png)
