### PR TITLE
Load cache before network for GraphQL queries

### DIFF
--- a/Classes/Systems/GithubClient.swift
+++ b/Classes/Systems/GithubClient.swift
@@ -121,7 +121,7 @@ struct GithubClient {
         resultHandler: OperationResultHandler<Query>? = nil
         ) -> Cancellable {
         NetworkActivityIndicatorManager.shared.incrementActivityCount()
-        return apollo.fetch(query: query, cachePolicy: .fetchIgnoringCacheData, resultHandler: { (result, error) in
+        return apollo.fetch(query: query, cachePolicy: .returnCacheDataAndFetch, resultHandler: { (result, error) in
             NetworkActivityIndicatorManager.shared.decrementActivityCount()
             resultHandler?(result, error)
         })


### PR DESCRIPTION
Closes #104

Changed cache policy from `.fetchIgnoringCacheData` to `.returnCacheDataAndFetch`
Added in https://github.com/apollographql/apollo-ios/pull/129