### PR TITLE
Issues use FlatCache for optimistic state changes

### DIFF
--- a/Classes/Issues/GithubClient+Issues.swift
+++ b/Classes/Issues/GithubClient+Issues.swift
@@ -41,7 +41,7 @@ extension GithubClient {
         number: Int,
         width: CGFloat,
         prependResult: IssueResult?,
-        completion: @escaping (Result<(String, [AutocompleteUser])>) -> Void
+        completion: @escaping (Result<(IssueResult, [AutocompleteUser])>) -> Void
         ) {
 
         let query = IssueOrPullRequestQuery(
@@ -126,7 +126,7 @@ extension GithubClient {
                         // update the cache so all listeners receive the new model
                         cache.set(value: issueResult)
 
-                        completion(.success((issueResult.id, mentionableUsers)))
+                        completion(.success((issueResult, mentionableUsers)))
                     }
                 }
             } else {

--- a/Classes/Issues/GithubClient+Issues.swift
+++ b/Classes/Issues/GithubClient+Issues.swift
@@ -105,7 +105,7 @@ extension GithubClient {
                     let canAdmin = repository?.viewerCanAdminister ?? false
 
                     let issueResult = IssueResult(
-                        subjectId: issueType.id,
+                        id: issueType.id,
                         pullRequest: issueType.pullRequest,
                         status: IssueStatusModel(status: status, pullRequest: issueType.pullRequest, locked: issueType.locked),
                         title: titleStringSizing(title: issueType.title, width: width),

--- a/Classes/Issues/IssueResult.swift
+++ b/Classes/Issues/IssueResult.swift
@@ -22,7 +22,6 @@ struct IssueResult: Cachable {
     let rootComment: IssueCommentModel?
     let reviewers: IssueAssigneesModel?
     let milestone: IssueMilestoneModel?
-    let mentionableUsers: [AutocompleteUser]
     let timelinePages: [IssueTimelinePage]
     let viewerCanUpdate: Bool
     let hasIssuesEnabled: Bool

--- a/Classes/Issues/IssueResult.swift
+++ b/Classes/Issues/IssueResult.swift
@@ -14,7 +14,6 @@ struct IssueResult: Cachable {
 
     let id: String
     let pullRequest: Bool
-
     let status: IssueStatusModel
     let title: NSAttributedStringSizing
     let labels: IssueLabelsModel
@@ -39,9 +38,64 @@ struct IssueResult: Cachable {
         return minStartCursor != nil
     }
 
+    func timelinePages(appending: ListDiffable) -> [IssueTimelinePage] {
+        let newPage: IssueTimelinePage
+        if let lastPage = timelinePages.last {
+            newPage = IssueTimelinePage(
+                startCursor: lastPage.startCursor,
+                viewModels: lastPage.viewModels + [appending]
+            )
+        } else {
+            newPage = IssueTimelinePage(
+                startCursor: nil,
+                viewModels: [appending]
+            )
+        }
+
+        let count = timelinePages.count
+        if count > 0 {
+            return timelinePages[0..<count - 1] + [newPage]
+        } else {
+            return [newPage]
+        }
+    }
+
+    func updated(
+        id: String? = nil,
+        pullRequest: Bool? = nil,
+        status: IssueStatusModel? = nil,
+        title: NSAttributedStringSizing? = nil,
+        labels: IssueLabelsModel? = nil,
+        assignee: IssueAssigneesModel? = nil,
+        rootComment: IssueCommentModel? = nil,
+        reviewers: IssueAssigneesModel? = nil,
+        milestone: IssueMilestoneModel? = nil,
+        timelinePages: [IssueTimelinePage]? = nil,
+        viewerCanUpdate: Bool? = nil,
+        hasIssuesEnabled: Bool? = nil,
+        viewerCanAdminister: Bool? = nil
+        ) -> IssueResult {
+        return IssueResult(
+            id: id ?? self.id,
+            pullRequest: pullRequest ?? self.pullRequest,
+            status: status ?? self.status,
+            title: title ?? self.title,
+            labels: labels ?? self.labels,
+            assignee: assignee ?? self.assignee,
+            rootComment: rootComment ?? self.rootComment,
+            reviewers: reviewers ?? self.reviewers,
+            milestone: milestone ?? self.milestone,
+            timelinePages: timelinePages ?? self.timelinePages,
+            viewerCanUpdate: viewerCanUpdate ?? self.viewerCanUpdate,
+            hasIssuesEnabled: hasIssuesEnabled ?? self.hasIssuesEnabled,
+            viewerCanAdminister: viewerCanAdminister ?? self.viewerCanAdminister
+        )
+    }
+
 }
 
 struct IssueTimelinePage {
     let startCursor: String?
     let viewModels: [ListDiffable]
 }
+

--- a/Classes/Issues/IssueResult.swift
+++ b/Classes/Issues/IssueResult.swift
@@ -8,10 +8,11 @@
 
 import Foundation
 import IGListKit
+import FlatCache
 
-struct IssueResult {
+struct IssueResult: Cachable {
 
-    let subjectId: String
+    let id: String
     let pullRequest: Bool
 
     let status: IssueStatusModel

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -193,10 +193,10 @@ IssueCommentSectionControllerDelegate {
 
         super.didPressRightButton(sender)
 
-        if let subjectId = current?.subjectId,
+        if let id = current?.id,
             let text = text {
             addCommentClient.addComment(
-                subjectId: subjectId,
+                subjectId: id,
                 body: text
             )
         }

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -375,39 +375,49 @@ FlatCacheListener {
     }
 
     func setStatus(close: Bool) {
-        guard let currentStatus = localStatusChange?.model ?? result?.status else { return }
-
-        let localModel = IssueStatusModel(
-            status: close ? .closed : .open,
-            pullRequest: currentStatus.pullRequest,
-            locked: currentStatus.locked
-        )
-        let localEvent = IssueStatusEventModel(
-            id: UUID().uuidString,
-            actor: client.sessionManager.focusedUserSession?.username ?? Constants.Strings.unknown,
-            commitHash: nil,
-            date: Date(),
-            status: close ? .closed : .reopened,
-            pullRequest: currentStatus.pullRequest
-        )
-
-        localStatusChange = (localModel, localEvent)
-        feed.adapter.performUpdates(animated: true)
+        guard let previous = result else { return }
 
         client.setStatus(
+            previous: previous,
             owner: model.owner,
             repo: model.repo,
             number: model.number,
-            status: close ? .closed : .open
-        ) { [weak self] result in
-            switch result {
-            case .error:
-                self?.localStatusChange = nil
-                self?.feed.adapter.performUpdates(animated: true)
-                ToastManager.showGenericError()
-            default: break // dont need to handle success since updated optimistically
-            }
-        }
+            close: close
+        )
+
+//        guard let currentStatus = localStatusChange?.model ?? result?.status else { return }
+//
+//        let localModel = IssueStatusModel(
+//            status: close ? .closed : .open,
+//            pullRequest: currentStatus.pullRequest,
+//            locked: currentStatus.locked
+//        )
+//        let localEvent = IssueStatusEventModel(
+//            id: UUID().uuidString,
+//            actor: client.sessionManager.focusedUserSession?.username ?? Constants.Strings.unknown,
+//            commitHash: nil,
+//            date: Date(),
+//            status: close ? .closed : .reopened,
+//            pullRequest: currentStatus.pullRequest
+//        )
+//
+//        localStatusChange = (localModel, localEvent)
+//        feed.adapter.performUpdates(animated: true)
+//
+//        client.setStatus(
+//            owner: model.owner,
+//            repo: model.repo,
+//            number: model.number,
+//            status: close ? .closed : .open
+//        ) { [weak self] result in
+//            switch result {
+//            case .error:
+//                self?.localStatusChange = nil
+//                self?.feed.adapter.performUpdates(animated: true)
+//                ToastManager.showGenericError()
+//            default: break // dont need to handle success since updated optimistically
+//            }
+//        }
     }
 
     func setLocked(_ locked: Bool) {

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -411,39 +411,14 @@ FlatCacheListener {
     }
 
     func setLocked(_ locked: Bool) {
-        guard let currentStatus = localStatusChange?.model ?? result?.status else { return }
-
-        let localModel = IssueStatusModel(
-            status: currentStatus.status,
-            pullRequest: currentStatus.pullRequest,
-            locked: locked
-        )
-        let localEvent = IssueStatusEventModel(
-            id: UUID().uuidString,
-            actor: client.sessionManager.focusedUserSession?.username ?? Constants.Strings.unknown,
-            commitHash: nil,
-            date: Date(),
-            status: locked ? .locked : .unlocked,
-            pullRequest: currentStatus.pullRequest
-        )
-
-        localStatusChange = (localModel, localEvent)
-        feed.adapter.performUpdates(animated: true)
-
+        guard let previous = result else { return }
         client.setLocked(
+            previous: previous,
             owner: model.owner,
             repo: model.repo,
             number: model.number,
             locked: locked
-        ) { [weak self] result in
-            switch result {
-            case .error:
-                self?.localStatusChange = nil
-                self?.feed.adapter.performUpdates(animated: true)
-                ToastManager.showGenericError()
-            default: break // dont need to handle success since updated optimistically
-            }
-        }
+        )
     }
 
     // MARK: ListAdapterDataSource


### PR DESCRIPTION
- Added helpers to `IssueResult` making it easy to get new, mutated objects
- Moved optimistic state stuff into client issues extension
- Removed local state mgmt from VC
- Issue VC uses `FlatCache` system to fetch data

Fixes #597