### PR TITLE
Use repository default branch rather than master for file view

### DIFF
--- a/Classes/Bookmark/BookmarkModel.swift
+++ b/Classes/Bookmark/BookmarkModel.swift
@@ -25,6 +25,7 @@ final class BookmarkModel: NSObject, NSCoding, Filterable {
     let number: Int
     let title: String
     let hasIssueEnabled: Bool
+    let defaultBranch: String
 
     init(
         type: NotificationType,
@@ -32,7 +33,8 @@ final class BookmarkModel: NSObject, NSCoding, Filterable {
         owner: String,
         number: Int = 0,
         title: String = "",
-        hasIssueEnabled: Bool = false
+        hasIssueEnabled: Bool = false,
+        defaultBranch: String = "master"
     ) {
         self.type = type
         self.name = name
@@ -40,6 +42,7 @@ final class BookmarkModel: NSObject, NSCoding, Filterable {
         self.number = number
         self.title = title
         self.hasIssueEnabled = hasIssueEnabled
+        self.defaultBranch = defaultBranch
     }
 
     convenience required init?(coder aDecoder: NSCoder) {

--- a/Classes/Bookmark/BookmarksViewController.swift
+++ b/Classes/Bookmark/BookmarksViewController.swift
@@ -144,6 +144,7 @@ BookmarksStoreListener {
             let repo = RepositoryDetails(
                 owner: bookmark.owner,
                 name: bookmark.name,
+                defaultBranch: bookmark.defaultBranch,
                 hasIssuesEnabled: bookmark.hasIssueEnabled
             )
             destinationViewController = RepositoryViewController(client: client, repo: repo)

--- a/Classes/Issues/GithubClient+Issues.swift
+++ b/Classes/Issues/GithubClient+Issues.swift
@@ -119,7 +119,8 @@ extension GithubClient {
                         timelinePages: [newPage] + (prependResult?.timelinePages ?? []),
                         viewerCanUpdate: issueType.viewerCanUpdate,
                         hasIssuesEnabled: repository?.hasIssuesEnabled ?? false,
-                        viewerCanAdminister: canAdmin
+                        viewerCanAdminister: canAdmin,
+                        defaultBranch: repository?.defaultBranchRef?.name ?? "master"
                     )
 
                     DispatchQueue.main.async {

--- a/Classes/Issues/IssueResult.swift
+++ b/Classes/Issues/IssueResult.swift
@@ -25,6 +25,7 @@ struct IssueResult: Cachable {
     let viewerCanUpdate: Bool
     let hasIssuesEnabled: Bool
     let viewerCanAdminister: Bool
+    let defaultBranch: String
 
     var timelineViewModels: [ListDiffable] {
         return timelinePages.reduce([], { $0 + $1.viewModels })
@@ -73,7 +74,8 @@ struct IssueResult: Cachable {
         timelinePages: [IssueTimelinePage]? = nil,
         viewerCanUpdate: Bool? = nil,
         hasIssuesEnabled: Bool? = nil,
-        viewerCanAdminister: Bool? = nil
+        viewerCanAdminister: Bool? = nil,
+        defaultBranch: String? = nil
         ) -> IssueResult {
         return IssueResult(
             id: id ?? self.id,
@@ -88,7 +90,8 @@ struct IssueResult: Cachable {
             timelinePages: timelinePages ?? self.timelinePages,
             viewerCanUpdate: viewerCanUpdate ?? self.viewerCanUpdate,
             hasIssuesEnabled: hasIssuesEnabled ?? self.hasIssuesEnabled,
-            viewerCanAdminister: viewerCanAdminister ?? self.viewerCanAdminister
+            viewerCanAdminister: viewerCanAdminister ?? self.viewerCanAdminister,
+            defaultBranch: defaultBranch ?? self.defaultBranch
         )
     }
 
@@ -98,4 +101,3 @@ struct IssueTimelinePage {
     let startCursor: String?
     let viewModels: [ListDiffable]
 }
-

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -250,12 +250,13 @@ FlatCacheListener {
     }
 
     func viewRepoAction() -> UIAlertAction? {
-        guard result != nil else { return nil }
-
+        guard let result = result else { return nil }
+        
         let repo = RepositoryDetails(
             owner: model.owner,
             name: model.repo,
-            hasIssuesEnabled: result?.hasIssuesEnabled ?? false
+            defaultBranch: result.defaultBranch,
+            hasIssuesEnabled: result.hasIssuesEnabled
         )
 
         weak var weakSelf = self
@@ -272,7 +273,8 @@ FlatCacheListener {
             name: model.repo,
             owner: model.owner,
             number: model.number,
-            title: result.title.attributedText.string
+            title: result.title.attributedText.string,
+            defaultBranch: result.defaultBranch
         )
         return AlertAction.toggleBookmark(store: store, model: bookmarkModel)
     }

--- a/Classes/Repository/GitHubClient+Repository.swift
+++ b/Classes/Repository/GitHubClient+Repository.swift
@@ -8,17 +8,16 @@
 
 import Foundation
 
-private let fixedBranch = "master"
-
 extension GithubClient {
 
     func fetchFiles(
         owner: String,
         repo: String,
+        branch: String,
         path: String,
         completion: @escaping (Result<[RepositoryFile]>) -> Void
         ) {
-        let query = RepoFilesQuery(owner: owner, name: repo, branchAndPath: "\(fixedBranch):\(path)")
+        let query = RepoFilesQuery(owner: owner, name: repo, branchAndPath: "\(branch):\(path)")
         fetch(query: query) { (result, error) in
             if let models = result?.data?.repository?.object?.asTree?.entries {
                 // trees A-Z first, then blobs A-Z
@@ -55,10 +54,11 @@ extension GithubClient {
     func fetchFile(
         owner: String,
         repo: String,
+        branch: String,
         path: String,
         completion: @escaping (FileResult) -> Void
         ) {
-        let query = RepoFileQuery(owner: owner, name: repo, branchAndPath: "\(fixedBranch):\(path)")
+        let query = RepoFileQuery(owner: owner, name: repo, branchAndPath: "\(branch):\(path)")
         fetch(query: query) { (result, error) in
             if let blob = result?.data?.repository?.object?.asBlob {
                 if let text = blob.text, !text.isEmpty {

--- a/Classes/Repository/RepositoryCodeBlobViewController.swift
+++ b/Classes/Repository/RepositoryCodeBlobViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 final class RepositoryCodeBlobViewController: UIViewController {
 
     private let client: GithubClient
+    private let branch: String
     private let path: String
     private let repo: RepositoryDetails
     private let scrollView = UIScrollView()
@@ -28,9 +29,10 @@ final class RepositoryCodeBlobViewController: UIViewController {
         return barButtonItem
     }()
 
-    init(client: GithubClient, repo: RepositoryDetails, path: String) {
+    init(client: GithubClient, repo: RepositoryDetails, branch: String, path: String) {
         self.client = client
         self.repo = repo
+        self.branch = branch
         self.path = path
         super.init(nibName: nil, bundle: nil)
         self.title = path
@@ -102,7 +104,7 @@ final class RepositoryCodeBlobViewController: UIViewController {
     }
 
     func fetch() {
-        client.fetchFile(owner: repo.owner, repo: repo.name, path: path) { [weak self] (result) in
+        client.fetchFile(owner: repo.owner, repo: repo.name, branch: branch, path: path) { [weak self] (result) in
             self?.feedRefresh.endRefreshing()
             switch result {
             case .success(let text):

--- a/Classes/Repository/RepositoryCodeDirectoryViewController.swift
+++ b/Classes/Repository/RepositoryCodeDirectoryViewController.swift
@@ -12,6 +12,7 @@ final class RepositoryCodeDirectoryViewController: UIViewController, UITableView
 
     private let tableView = UITableView(frame: .zero, style: .plain)
     private let client: GithubClient
+    private let branch: String
     private let path: String
     private let repo: RepositoryDetails
     private let cellIdentifier = "cell"
@@ -19,9 +20,10 @@ final class RepositoryCodeDirectoryViewController: UIViewController, UITableView
     private var files = [RepositoryFile]()
     private let isRoot: Bool
 
-    init(client: GithubClient, repo: RepositoryDetails, path: String, isRoot: Bool) {
+    init(client: GithubClient, repo: RepositoryDetails, branch: String, path: String, isRoot: Bool) {
         self.client = client
         self.repo = repo
+        self.branch = branch
         self.path = path
         self.isRoot = isRoot
         super.init(nibName: nil, bundle: nil)
@@ -75,7 +77,7 @@ final class RepositoryCodeDirectoryViewController: UIViewController, UITableView
     // MARK: Private API
 
     func fetch() {
-        client.fetchFiles(owner: repo.owner, repo: repo.name, path: path) { [weak self] (result) in
+        client.fetchFiles(owner: repo.owner, repo: repo.name, branch: branch, path: path) { [weak self] (result) in
             switch result {
             case .error:
                 ToastManager.showGenericError()
@@ -120,11 +122,12 @@ final class RepositoryCodeDirectoryViewController: UIViewController, UITableView
             controller = RepositoryCodeDirectoryViewController(
                 client: client,
                 repo: repo,
+                branch: branch,
                 path: newPath,
                 isRoot: false
             )
         } else {
-            controller = RepositoryCodeBlobViewController(client: client, repo: repo, path: newPath)
+            controller = RepositoryCodeBlobViewController(client: client, repo: repo, branch: branch, path: newPath)
         }
         navigationController?.pushViewController(controller, animated: true)
     }

--- a/Classes/Repository/RepositoryDetails.swift
+++ b/Classes/Repository/RepositoryDetails.swift
@@ -11,6 +11,7 @@ import Foundation
 struct RepositoryDetails: Codable {
     let owner: String
     let name: String
+    let defaultBranch: String
     let hasIssuesEnabled: Bool
 
     var ownerURL: URL {
@@ -23,6 +24,7 @@ extension RepositoryDetails: Equatable {
     static func == (lhs: RepositoryDetails, rhs: RepositoryDetails) -> Bool {
         return lhs.owner == rhs.owner &&
             lhs.name == rhs.name &&
+            lhs.defaultBranch == rhs.defaultBranch &&
             lhs.hasIssuesEnabled == rhs.hasIssuesEnabled
     }
 }

--- a/Classes/Repository/RepositoryViewController.swift
+++ b/Classes/Repository/RepositoryViewController.swift
@@ -30,7 +30,7 @@ NewIssueTableViewControllerDelegate {
         }
         controllers += [
             RepositoryIssuesViewController(client: client, repo: repo, type: .pullRequests),
-            RepositoryCodeDirectoryViewController(client: client, repo: repo, path: "", isRoot: true)
+            RepositoryCodeDirectoryViewController(client: client, repo: repo, branch: repo.defaultBranch, path: "", isRoot: true)
         ]
         self.controllers = controllers
 
@@ -108,7 +108,8 @@ NewIssueTableViewControllerDelegate {
             type: .repo,
             name: repo.name,
             owner: repo.owner,
-            hasIssueEnabled: repo.hasIssuesEnabled
+            hasIssueEnabled: repo.hasIssuesEnabled,
+            defaultBranch: repo.defaultBranch
         )
         return AlertAction.toggleBookmark(store: store, model: bookmarkModel)
     }

--- a/Classes/Search/GithubClient+Search.swift
+++ b/Classes/Search/GithubClient+Search.swift
@@ -54,7 +54,8 @@ extension GithubClient {
                         description: repo.description ?? "",
                         stars: repo.stargazers.totalCount,
                         hasIssuesEnabled: repo.hasIssuesEnabled,
-                        primaryLanguage: primaryLanguage
+                        primaryLanguage: primaryLanguage,
+                        defaultBranch: repo.defaultBranchRef?.name ?? "master"
                     )
                     builder.append(model)
                 }

--- a/Classes/Search/SearchRepoResult.swift
+++ b/Classes/Search/SearchRepoResult.swift
@@ -23,6 +23,7 @@ class SearchRepoResult: ListDiffable {
     let stars: Int
     let hasIssuesEnabled: Bool
     let primaryLanguage: GithubLanguage?
+    let defaultBranch: String
 
     init(
         id: String,
@@ -31,7 +32,8 @@ class SearchRepoResult: ListDiffable {
         description: String,
         stars: Int,
         hasIssuesEnabled: Bool,
-        primaryLanguage: GithubLanguage?
+        primaryLanguage: GithubLanguage?,
+        defaultBranch: String
         ) {
         self.id = id
         self.owner = owner
@@ -40,6 +42,7 @@ class SearchRepoResult: ListDiffable {
         self.stars = stars
         self.hasIssuesEnabled = hasIssuesEnabled
         self.primaryLanguage = primaryLanguage
+        self.defaultBranch = defaultBranch
     }
 
     func diffIdentifier() -> NSObjectProtocol {

--- a/Classes/Search/SearchResultSectionController.swift
+++ b/Classes/Search/SearchResultSectionController.swift
@@ -41,7 +41,13 @@ final class SearchResultSectionController: ListGenericSectionController<SearchRe
 
     override func didSelectItem(at index: Int) {
         guard let object = object else { return }
-        let repo = RepositoryDetails(owner: object.owner, name: object.name, hasIssuesEnabled: object.hasIssuesEnabled)
+        
+        let repo = RepositoryDetails(
+            owner: object.owner,
+            name: object.name,
+            defaultBranch: object.defaultBranch,
+            hasIssuesEnabled: object.hasIssuesEnabled
+        )
 
         delegate?.didSelect(sectionController: self, repo: repo)
 

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -2025,7 +2025,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\"";
 		};
 		F8AD268F7DD148D9C5F574B2 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/FreetimeTests/Search Tests/SearchQueryTests.swift
+++ b/FreetimeTests/Search Tests/SearchQueryTests.swift
@@ -32,7 +32,7 @@ class SearchQueryTests: XCTestCase {
     }
 
     func test_encodesAndDecodes_recentlyViewed() {
-        let recentlyViewed = RepositoryDetails(owner: "Instagram", name: "IGListKit", hasIssuesEnabled: true)
+        let recentlyViewed = RepositoryDetails(owner: "Instagram", name: "IGListKit", defaultBranch: "master", hasIssuesEnabled: true)
         let query = SearchQuery.recentlyViewed(recentlyViewed)
         let data = try? encoder.encode(query)
 
@@ -46,8 +46,8 @@ class SearchQueryTests: XCTestCase {
         let chickenWings = SearchQuery.search("Bonchon")
         let dimSum = SearchQuery.search("Nom Wah")
 
-        let koreanBBQDetails = RepositoryDetails(owner: "678 Corp", name: "Kang Ho Dong Baekjeong", hasIssuesEnabled: false)
-        let hotPotDetails = RepositoryDetails(owner: "Favor Taste", name: "99", hasIssuesEnabled: false)
+        let koreanBBQDetails = RepositoryDetails(owner: "678 Corp", name: "Kang Ho Dong Baekjeong", defaultBranch: "master", hasIssuesEnabled: false)
+        let hotPotDetails = RepositoryDetails(owner: "Favor Taste", name: "99", defaultBranch: "dev", hasIssuesEnabled: false)
         let koreanBBQ = SearchQuery.recentlyViewed(koreanBBQDetails)
         let hotPot = SearchQuery.recentlyViewed(hotPotDetails)
 

--- a/FreetimeTests/Search Tests/SearchRecentViewModelTests.swift
+++ b/FreetimeTests/Search Tests/SearchRecentViewModelTests.swift
@@ -21,7 +21,7 @@ class SearchRecentViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         searchQuery = SearchQuery.search("Pythonic")
-        let kickstarter = RepositoryDetails(owner: "Kickstarter", name: "ios-oss", hasIssuesEnabled: true)
+        let kickstarter = RepositoryDetails(owner: "Kickstarter", name: "ios-oss", defaultBranch: "master", hasIssuesEnabled: true)
         recentlyViewedQuery = SearchQuery.recentlyViewed(kickstarter)
 
         searchViewModel = SearchRecentViewModel(query: searchQuery)

--- a/gql/API.swift
+++ b/gql/API.swift
@@ -3,7 +3,7 @@
 import Apollo
 
 /// Emojis that can be attached to Issues, Pull Requests and Comments.
-public enum ReactionContent: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
+public enum ReactionContent: String {
   /// Represents the 👍 emoji.
   case thumbsUp = "THUMBS_UP"
   /// Represents the 👎 emoji.
@@ -18,8 +18,10 @@ public enum ReactionContent: String, Apollo.JSONDecodable, Apollo.JSONEncodable 
   case heart = "HEART"
 }
 
+extension ReactionContent: Apollo.JSONDecodable, Apollo.JSONEncodable {}
+
 /// The possible states of a pull request review.
-public enum PullRequestReviewState: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
+public enum PullRequestReviewState: String {
   /// A review that has not yet been submitted.
   case pending = "PENDING"
   /// An informational review.
@@ -32,16 +34,20 @@ public enum PullRequestReviewState: String, Apollo.JSONDecodable, Apollo.JSONEnc
   case dismissed = "DISMISSED"
 }
 
+extension PullRequestReviewState: Apollo.JSONDecodable, Apollo.JSONEncodable {}
+
 /// The possible states of an issue.
-public enum IssueState: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
+public enum IssueState: String {
   /// An issue that is still open
   case `open` = "OPEN"
   /// An issue that has been closed
   case closed = "CLOSED"
 }
 
+extension IssueState: Apollo.JSONDecodable, Apollo.JSONEncodable {}
+
 /// The possible states of a pull request.
-public enum PullRequestState: String, Apollo.JSONDecodable, Apollo.JSONEncodable {
+public enum PullRequestState: String {
   /// A pull request that is still open.
   case `open` = "OPEN"
   /// A pull request that has been closed without being merged.
@@ -49,6 +55,8 @@ public enum PullRequestState: String, Apollo.JSONDecodable, Apollo.JSONEncodable
   /// A pull request that has been closed by being merged.
   case merged = "MERGED"
 }
+
+extension PullRequestState: Apollo.JSONDecodable, Apollo.JSONEncodable {}
 
 public final class AddCommentMutation: GraphQLMutation {
   public static let operationString =
@@ -956,7 +964,7 @@ public final class AddReactionMutation: GraphQLMutation {
 
 public final class IssueOrPullRequestQuery: GraphQLQuery {
   public static let operationString =
-    "query IssueOrPullRequest($owner: String!, $repo: String!, $number: Int!, $page_size: Int!, $before: String) {\n  repository(owner: $owner, name: $repo) {\n    __typename\n    name\n    hasIssuesEnabled\n    viewerCanAdminister\n    mentionableUsers(first: 20) {\n      __typename\n      nodes {\n        __typename\n        avatarUrl\n        login\n      }\n    }\n    issueOrPullRequest(number: $number) {\n      __typename\n      ... on Issue {\n        timeline(last: $page_size, before: $before) {\n          __typename\n          pageInfo {\n            __typename\n            ...headPaging\n          }\n          nodes {\n            __typename\n            ... on Commit {\n              ...nodeFields\n              author {\n                __typename\n                user {\n                  __typename\n                  login\n                  avatarUrl\n                }\n              }\n              oid\n              messageHeadline\n            }\n            ... on IssueComment {\n              ...nodeFields\n              ...reactionFields\n              ...commentFields\n              ...updatableFields\n              ...deletableFields\n            }\n            ... on LabeledEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              label {\n                __typename\n                color\n                name\n              }\n              createdAt\n            }\n            ... on UnlabeledEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              label {\n                __typename\n                color\n                name\n              }\n              createdAt\n            }\n            ... on ClosedEvent {\n              ...nodeFields\n              closedCommit: commit {\n                __typename\n                oid\n              }\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on ReopenedEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on RenamedTitleEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              createdAt\n              currentTitle\n            }\n            ... on LockedEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on UnlockedEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on ReferencedEvent {\n              createdAt\n              ...nodeFields\n              refCommit: commit {\n                __typename\n                oid\n              }\n              actor {\n                __typename\n                login\n              }\n              commitRepository {\n                __typename\n                ...referencedRepositoryFields\n              }\n              subject {\n                __typename\n                ... on Issue {\n                  title\n                  number\n                  closed\n                }\n                ... on PullRequest {\n                  title\n                  number\n                  closed\n                  merged\n                }\n              }\n            }\n            ... on RenamedTitleEvent {\n              ...nodeFields\n              createdAt\n              currentTitle\n              previousTitle\n              actor {\n                __typename\n                login\n              }\n            }\n            ... on AssignedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              user {\n                __typename\n                login\n              }\n            }\n            ... on UnassignedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              user {\n                __typename\n                login\n              }\n            }\n            ... on MilestonedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              milestoneTitle\n            }\n            ... on DemilestonedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              milestoneTitle\n            }\n          }\n        }\n        milestone {\n          __typename\n          ...milestoneFields\n        }\n        ...reactionFields\n        ...commentFields\n        ...lockableFields\n        ...closableFields\n        ...labelableFields\n        ...updatableFields\n        ...nodeFields\n        ...assigneeFields\n        number\n        title\n      }\n      ... on PullRequest {\n        timeline(last: $page_size, before: $before) {\n          __typename\n          pageInfo {\n            __typename\n            ...headPaging\n          }\n          nodes {\n            __typename\n            ... on Commit {\n              ...nodeFields\n              author {\n                __typename\n                user {\n                  __typename\n                  login\n                  avatarUrl\n                }\n              }\n              oid\n              messageHeadline\n            }\n            ... on IssueComment {\n              ...nodeFields\n              ...reactionFields\n              ...commentFields\n              ...updatableFields\n              ...deletableFields\n            }\n            ... on LabeledEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              label {\n                __typename\n                color\n                name\n              }\n              createdAt\n            }\n            ... on UnlabeledEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              label {\n                __typename\n                color\n                name\n              }\n              createdAt\n            }\n            ... on ClosedEvent {\n              ...nodeFields\n              closedCommit: commit {\n                __typename\n                oid\n              }\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on ReopenedEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on RenamedTitleEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              createdAt\n              currentTitle\n            }\n            ... on LockedEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on UnlockedEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on MergedEvent {\n              ...nodeFields\n              mergedCommit: commit {\n                __typename\n                oid\n              }\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on PullRequestReviewThread {\n              comments(first: $page_size) {\n                __typename\n                nodes {\n                  __typename\n                  ...reactionFields\n                  ...nodeFields\n                  ...commentFields\n                  path\n                  diffHunk\n                }\n              }\n            }\n            ... on PullRequestReview {\n              ...nodeFields\n              ...commentFields\n              state\n              submittedAt\n              author {\n                __typename\n                login\n              }\n            }\n            ... on ReferencedEvent {\n              createdAt\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              commitRepository {\n                __typename\n                ...referencedRepositoryFields\n              }\n              subject {\n                __typename\n                ... on Issue {\n                  title\n                  number\n                  closed\n                }\n                ... on PullRequest {\n                  title\n                  number\n                  closed\n                  merged\n                }\n              }\n            }\n            ... on RenamedTitleEvent {\n              ...nodeFields\n              createdAt\n              currentTitle\n              previousTitle\n              actor {\n                __typename\n                login\n              }\n            }\n            ... on AssignedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              user {\n                __typename\n                login\n              }\n            }\n            ... on UnassignedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              user {\n                __typename\n                login\n              }\n            }\n            ... on ReviewRequestedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              subject {\n                __typename\n                login\n              }\n            }\n            ... on ReviewRequestRemovedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              subject {\n                __typename\n                login\n              }\n            }\n            ... on MilestonedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              milestoneTitle\n            }\n            ... on DemilestonedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              milestoneTitle\n            }\n          }\n        }\n        reviewRequests(first: $page_size) {\n          __typename\n          nodes {\n            __typename\n            reviewer {\n              __typename\n              login\n              avatarUrl\n            }\n          }\n        }\n        milestone {\n          __typename\n          ...milestoneFields\n        }\n        ...reactionFields\n        ...commentFields\n        ...lockableFields\n        ...closableFields\n        ...labelableFields\n        ...updatableFields\n        ...nodeFields\n        ...assigneeFields\n        number\n        title\n        merged\n      }\n    }\n  }\n}"
+    "query IssueOrPullRequest($owner: String!, $repo: String!, $number: Int!, $page_size: Int!, $before: String) {\n  repository(owner: $owner, name: $repo) {\n    __typename\n    name\n    hasIssuesEnabled\n    viewerCanAdminister\n    mentionableUsers(first: 20) {\n      __typename\n      nodes {\n        __typename\n        avatarUrl\n        login\n      }\n    }\n    defaultBranchRef {\n      __typename\n      name\n    }\n    issueOrPullRequest(number: $number) {\n      __typename\n      ... on Issue {\n        timeline(last: $page_size, before: $before) {\n          __typename\n          pageInfo {\n            __typename\n            ...headPaging\n          }\n          nodes {\n            __typename\n            ... on Commit {\n              ...nodeFields\n              author {\n                __typename\n                user {\n                  __typename\n                  login\n                  avatarUrl\n                }\n              }\n              oid\n              messageHeadline\n            }\n            ... on IssueComment {\n              ...nodeFields\n              ...reactionFields\n              ...commentFields\n              ...updatableFields\n              ...deletableFields\n            }\n            ... on LabeledEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              label {\n                __typename\n                color\n                name\n              }\n              createdAt\n            }\n            ... on UnlabeledEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              label {\n                __typename\n                color\n                name\n              }\n              createdAt\n            }\n            ... on ClosedEvent {\n              ...nodeFields\n              closedCommit: commit {\n                __typename\n                oid\n              }\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on ReopenedEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on RenamedTitleEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              createdAt\n              currentTitle\n            }\n            ... on LockedEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on UnlockedEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on ReferencedEvent {\n              createdAt\n              ...nodeFields\n              refCommit: commit {\n                __typename\n                oid\n              }\n              actor {\n                __typename\n                login\n              }\n              commitRepository {\n                __typename\n                ...referencedRepositoryFields\n              }\n              subject {\n                __typename\n                ... on Issue {\n                  title\n                  number\n                  closed\n                }\n                ... on PullRequest {\n                  title\n                  number\n                  closed\n                  merged\n                }\n              }\n            }\n            ... on RenamedTitleEvent {\n              ...nodeFields\n              createdAt\n              currentTitle\n              previousTitle\n              actor {\n                __typename\n                login\n              }\n            }\n            ... on AssignedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              user {\n                __typename\n                login\n              }\n            }\n            ... on UnassignedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              user {\n                __typename\n                login\n              }\n            }\n            ... on MilestonedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              milestoneTitle\n            }\n            ... on DemilestonedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              milestoneTitle\n            }\n          }\n        }\n        milestone {\n          __typename\n          ...milestoneFields\n        }\n        ...reactionFields\n        ...commentFields\n        ...lockableFields\n        ...closableFields\n        ...labelableFields\n        ...updatableFields\n        ...nodeFields\n        ...assigneeFields\n        number\n        title\n      }\n      ... on PullRequest {\n        timeline(last: $page_size, before: $before) {\n          __typename\n          pageInfo {\n            __typename\n            ...headPaging\n          }\n          nodes {\n            __typename\n            ... on Commit {\n              ...nodeFields\n              author {\n                __typename\n                user {\n                  __typename\n                  login\n                  avatarUrl\n                }\n              }\n              oid\n              messageHeadline\n            }\n            ... on IssueComment {\n              ...nodeFields\n              ...reactionFields\n              ...commentFields\n              ...updatableFields\n              ...deletableFields\n            }\n            ... on LabeledEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              label {\n                __typename\n                color\n                name\n              }\n              createdAt\n            }\n            ... on UnlabeledEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              label {\n                __typename\n                color\n                name\n              }\n              createdAt\n            }\n            ... on ClosedEvent {\n              ...nodeFields\n              closedCommit: commit {\n                __typename\n                oid\n              }\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on ReopenedEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on RenamedTitleEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              createdAt\n              currentTitle\n            }\n            ... on LockedEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on UnlockedEvent {\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on MergedEvent {\n              ...nodeFields\n              mergedCommit: commit {\n                __typename\n                oid\n              }\n              actor {\n                __typename\n                login\n              }\n              createdAt\n            }\n            ... on PullRequestReviewThread {\n              comments(first: $page_size) {\n                __typename\n                nodes {\n                  __typename\n                  ...reactionFields\n                  ...nodeFields\n                  ...commentFields\n                  path\n                  diffHunk\n                }\n              }\n            }\n            ... on PullRequestReview {\n              ...nodeFields\n              ...commentFields\n              state\n              submittedAt\n              author {\n                __typename\n                login\n              }\n            }\n            ... on ReferencedEvent {\n              createdAt\n              ...nodeFields\n              actor {\n                __typename\n                login\n              }\n              commitRepository {\n                __typename\n                ...referencedRepositoryFields\n              }\n              subject {\n                __typename\n                ... on Issue {\n                  title\n                  number\n                  closed\n                }\n                ... on PullRequest {\n                  title\n                  number\n                  closed\n                  merged\n                }\n              }\n            }\n            ... on RenamedTitleEvent {\n              ...nodeFields\n              createdAt\n              currentTitle\n              previousTitle\n              actor {\n                __typename\n                login\n              }\n            }\n            ... on AssignedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              user {\n                __typename\n                login\n              }\n            }\n            ... on UnassignedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              user {\n                __typename\n                login\n              }\n            }\n            ... on ReviewRequestedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              subject {\n                __typename\n                login\n              }\n            }\n            ... on ReviewRequestRemovedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              subject {\n                __typename\n                login\n              }\n            }\n            ... on MilestonedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              milestoneTitle\n            }\n            ... on DemilestonedEvent {\n              ...nodeFields\n              createdAt\n              actor {\n                __typename\n                login\n              }\n              milestoneTitle\n            }\n          }\n        }\n        reviewRequests(first: $page_size) {\n          __typename\n          nodes {\n            __typename\n            reviewer {\n              __typename\n              login\n              avatarUrl\n            }\n          }\n        }\n        milestone {\n          __typename\n          ...milestoneFields\n        }\n        ...reactionFields\n        ...commentFields\n        ...lockableFields\n        ...closableFields\n        ...labelableFields\n        ...updatableFields\n        ...nodeFields\n        ...assigneeFields\n        number\n        title\n        merged\n      }\n    }\n  }\n}"
 
   public static var requestString: String { return operationString.appending(HeadPaging.fragmentString).appending(NodeFields.fragmentString).appending(ReactionFields.fragmentString).appending(CommentFields.fragmentString).appending(UpdatableFields.fragmentString).appending(DeletableFields.fragmentString).appending(ReferencedRepositoryFields.fragmentString).appending(MilestoneFields.fragmentString).appending(LockableFields.fragmentString).appending(ClosableFields.fragmentString).appending(LabelableFields.fragmentString).appending(AssigneeFields.fragmentString) }
 
@@ -1014,6 +1022,7 @@ public final class IssueOrPullRequestQuery: GraphQLQuery {
         GraphQLField("hasIssuesEnabled", type: .nonNull(.scalar(Bool.self))),
         GraphQLField("viewerCanAdminister", type: .nonNull(.scalar(Bool.self))),
         GraphQLField("mentionableUsers", arguments: ["first": 20], type: .nonNull(.object(MentionableUser.selections))),
+        GraphQLField("defaultBranchRef", type: .object(DefaultBranchRef.selections)),
         GraphQLField("issueOrPullRequest", arguments: ["number": GraphQLVariable("number")], type: .object(IssueOrPullRequest.selections)),
       ]
 
@@ -1023,8 +1032,8 @@ public final class IssueOrPullRequestQuery: GraphQLQuery {
         self.snapshot = snapshot
       }
 
-      public init(name: String, hasIssuesEnabled: Bool, viewerCanAdminister: Bool, mentionableUsers: MentionableUser, issueOrPullRequest: IssueOrPullRequest? = nil) {
-        self.init(snapshot: ["__typename": "Repository", "name": name, "hasIssuesEnabled": hasIssuesEnabled, "viewerCanAdminister": viewerCanAdminister, "mentionableUsers": mentionableUsers.snapshot, "issueOrPullRequest": issueOrPullRequest.flatMap { $0.snapshot }])
+      public init(name: String, hasIssuesEnabled: Bool, viewerCanAdminister: Bool, mentionableUsers: MentionableUser, defaultBranchRef: DefaultBranchRef? = nil, issueOrPullRequest: IssueOrPullRequest? = nil) {
+        self.init(snapshot: ["__typename": "Repository", "name": name, "hasIssuesEnabled": hasIssuesEnabled, "viewerCanAdminister": viewerCanAdminister, "mentionableUsers": mentionableUsers.snapshot, "defaultBranchRef": defaultBranchRef.flatMap { $0.snapshot }, "issueOrPullRequest": issueOrPullRequest.flatMap { $0.snapshot }])
       }
 
       public var __typename: String {
@@ -1073,6 +1082,16 @@ public final class IssueOrPullRequestQuery: GraphQLQuery {
         }
         set {
           snapshot.updateValue(newValue.snapshot, forKey: "mentionableUsers")
+        }
+      }
+
+      /// The Ref associated with the repository's default branch.
+      public var defaultBranchRef: DefaultBranchRef? {
+        get {
+          return (snapshot["defaultBranchRef"] as? Snapshot).flatMap { DefaultBranchRef(snapshot: $0) }
+        }
+        set {
+          snapshot.updateValue(newValue?.snapshot, forKey: "defaultBranchRef")
         }
       }
 
@@ -1169,6 +1188,44 @@ public final class IssueOrPullRequestQuery: GraphQLQuery {
             set {
               snapshot.updateValue(newValue, forKey: "login")
             }
+          }
+        }
+      }
+
+      public struct DefaultBranchRef: GraphQLSelectionSet {
+        public static let possibleTypes = ["Ref"]
+
+        public static let selections: [GraphQLSelection] = [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("name", type: .nonNull(.scalar(String.self))),
+        ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+          self.snapshot = snapshot
+        }
+
+        public init(name: String) {
+          self.init(snapshot: ["__typename": "Ref", "name": name])
+        }
+
+        public var __typename: String {
+          get {
+            return snapshot["__typename"]! as! String
+          }
+          set {
+            snapshot.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        /// The ref name.
+        public var name: String {
+          get {
+            return snapshot["name"]! as! String
+          }
+          set {
+            snapshot.updateValue(newValue, forKey: "name")
           }
         }
       }
@@ -12742,7 +12799,7 @@ public final class RepositoryLabelsQuery: GraphQLQuery {
 
 public final class SearchReposQuery: GraphQLQuery {
   public static let operationString =
-    "query SearchRepos($search: String!, $before: String) {\n  search(first: 100, query: $search, type: REPOSITORY, before: $before) {\n    __typename\n    nodes {\n      __typename\n      ... on Repository {\n        id\n        name\n        hasIssuesEnabled\n        owner {\n          __typename\n          login\n        }\n        description\n        pushedAt\n        primaryLanguage {\n          __typename\n          name\n          color\n        }\n        stargazers {\n          __typename\n          totalCount\n        }\n      }\n    }\n    pageInfo {\n      __typename\n      endCursor\n      hasNextPage\n    }\n    repositoryCount\n  }\n}"
+    "query SearchRepos($search: String!, $before: String) {\n  search(first: 100, query: $search, type: REPOSITORY, before: $before) {\n    __typename\n    nodes {\n      __typename\n      ... on Repository {\n        id\n        name\n        hasIssuesEnabled\n        owner {\n          __typename\n          login\n        }\n        description\n        pushedAt\n        primaryLanguage {\n          __typename\n          name\n          color\n        }\n        stargazers {\n          __typename\n          totalCount\n        }\n        defaultBranchRef {\n          __typename\n          name\n        }\n      }\n    }\n    pageInfo {\n      __typename\n      endCursor\n      hasNextPage\n    }\n    repositoryCount\n  }\n}"
 
   public var search: String
   public var before: String?
@@ -12876,8 +12933,8 @@ public final class SearchReposQuery: GraphQLQuery {
           return Node(snapshot: ["__typename": "Organization"])
         }
 
-        public static func makeRepository(id: GraphQLID, name: String, hasIssuesEnabled: Bool, owner: AsRepository.Owner, description: String? = nil, pushedAt: String? = nil, primaryLanguage: AsRepository.PrimaryLanguage? = nil, stargazers: AsRepository.Stargazer) -> Node {
-          return Node(snapshot: ["__typename": "Repository", "id": id, "name": name, "hasIssuesEnabled": hasIssuesEnabled, "owner": owner.snapshot, "description": description, "pushedAt": pushedAt, "primaryLanguage": primaryLanguage.flatMap { $0.snapshot }, "stargazers": stargazers.snapshot])
+        public static func makeRepository(id: GraphQLID, name: String, hasIssuesEnabled: Bool, owner: AsRepository.Owner, description: String? = nil, pushedAt: String? = nil, primaryLanguage: AsRepository.PrimaryLanguage? = nil, stargazers: AsRepository.Stargazer, defaultBranchRef: AsRepository.DefaultBranchRef? = nil) -> Node {
+          return Node(snapshot: ["__typename": "Repository", "id": id, "name": name, "hasIssuesEnabled": hasIssuesEnabled, "owner": owner.snapshot, "description": description, "pushedAt": pushedAt, "primaryLanguage": primaryLanguage.flatMap { $0.snapshot }, "stargazers": stargazers.snapshot, "defaultBranchRef": defaultBranchRef.flatMap { $0.snapshot }])
         }
 
         public var __typename: String {
@@ -12913,6 +12970,7 @@ public final class SearchReposQuery: GraphQLQuery {
             GraphQLField("pushedAt", type: .scalar(String.self)),
             GraphQLField("primaryLanguage", type: .object(PrimaryLanguage.selections)),
             GraphQLField("stargazers", type: .nonNull(.object(Stargazer.selections))),
+            GraphQLField("defaultBranchRef", type: .object(DefaultBranchRef.selections)),
           ]
 
           public var snapshot: Snapshot
@@ -12921,8 +12979,8 @@ public final class SearchReposQuery: GraphQLQuery {
             self.snapshot = snapshot
           }
 
-          public init(id: GraphQLID, name: String, hasIssuesEnabled: Bool, owner: Owner, description: String? = nil, pushedAt: String? = nil, primaryLanguage: PrimaryLanguage? = nil, stargazers: Stargazer) {
-            self.init(snapshot: ["__typename": "Repository", "id": id, "name": name, "hasIssuesEnabled": hasIssuesEnabled, "owner": owner.snapshot, "description": description, "pushedAt": pushedAt, "primaryLanguage": primaryLanguage.flatMap { $0.snapshot }, "stargazers": stargazers.snapshot])
+          public init(id: GraphQLID, name: String, hasIssuesEnabled: Bool, owner: Owner, description: String? = nil, pushedAt: String? = nil, primaryLanguage: PrimaryLanguage? = nil, stargazers: Stargazer, defaultBranchRef: DefaultBranchRef? = nil) {
+            self.init(snapshot: ["__typename": "Repository", "id": id, "name": name, "hasIssuesEnabled": hasIssuesEnabled, "owner": owner.snapshot, "description": description, "pushedAt": pushedAt, "primaryLanguage": primaryLanguage.flatMap { $0.snapshot }, "stargazers": stargazers.snapshot, "defaultBranchRef": defaultBranchRef.flatMap { $0.snapshot }])
           }
 
           public var __typename: String {
@@ -13010,6 +13068,16 @@ public final class SearchReposQuery: GraphQLQuery {
             }
             set {
               snapshot.updateValue(newValue.snapshot, forKey: "stargazers")
+            }
+          }
+
+          /// The Ref associated with the repository's default branch.
+          public var defaultBranchRef: DefaultBranchRef? {
+            get {
+              return (snapshot["defaultBranchRef"] as? Snapshot).flatMap { DefaultBranchRef(snapshot: $0) }
+            }
+            set {
+              snapshot.updateValue(newValue?.snapshot, forKey: "defaultBranchRef")
             }
           }
 
@@ -13138,6 +13206,44 @@ public final class SearchReposQuery: GraphQLQuery {
               }
               set {
                 snapshot.updateValue(newValue, forKey: "totalCount")
+              }
+            }
+          }
+
+          public struct DefaultBranchRef: GraphQLSelectionSet {
+            public static let possibleTypes = ["Ref"]
+
+            public static let selections: [GraphQLSelection] = [
+              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+              GraphQLField("name", type: .nonNull(.scalar(String.self))),
+            ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+              self.snapshot = snapshot
+            }
+
+            public init(name: String) {
+              self.init(snapshot: ["__typename": "Ref", "name": name])
+            }
+
+            public var __typename: String {
+              get {
+                return snapshot["__typename"]! as! String
+              }
+              set {
+                snapshot.updateValue(newValue, forKey: "__typename")
+              }
+            }
+
+            /// The ref name.
+            public var name: String {
+              get {
+                return snapshot["name"]! as! String
+              }
+              set {
+                snapshot.updateValue(newValue, forKey: "name")
               }
             }
           }

--- a/gql/IssueOrPullRequest.graphql
+++ b/gql/IssueOrPullRequest.graphql
@@ -9,6 +9,9 @@ query IssueOrPullRequest($owner: String!, $repo: String!, $number: Int!, $page_s
         login
       }
     }
+    defaultBranchRef {
+      name
+    }
     issueOrPullRequest(number: $number) {
       ... on Issue {
         timeline(last: $page_size, before: $before) {

--- a/gql/SearchRepos.graphql
+++ b/gql/SearchRepos.graphql
@@ -18,6 +18,9 @@ query SearchRepos($search: String!, $before: String) {
         stargazers {
           totalCount
         }
+        defaultBranchRef {
+          name
+        }
       }
     }
 


### PR DESCRIPTION
Closes #824 

Stores the defaultBranch off a repository and uses that for the code view. We could fetch it once the user goes to the page, but that would then require two separate requests which I felt was a tad overkill for this.

I made the conscious choice to pass the branch through to the code view rather than assuming it as the default branch from the repository details model in order to allow future expansion and link to a certain branch (#441)

Precursor to adding functionality of changing branches on the fly, even if we did support that - this functionality should be there as per GitHub desktop.