### PR TITLE
Display a "no description given" message if the root comment is empty

### DIFF
--- a/Classes/Issues/Comments/IssueCommentModel.swift
+++ b/Classes/Issues/Comments/IssueCommentModel.swift
@@ -51,7 +51,7 @@ final class IssueCommentModel: ListDiffable {
         self.collapse = collapse
         self.threadState = threadState
         self.number = number
-        self.rawMarkdown = rawMarkdown
+        self.rawMarkdown = (rawMarkdown.isEmpty && isRoot) ? "*\(Constants.Strings.noDescriptionProvided)*" : rawMarkdown
         self.viewerCanUpdate = viewerCanUpdate
         self.viewerCanDelete = viewerCanDelete
         self.isRoot = isRoot

--- a/Classes/Views/Constants.swift
+++ b/Classes/Views/Constants.swift
@@ -46,5 +46,6 @@ enum Constants {
         static let bookmark = NSLocalizedString("Bookmark", comment: "")
         static let removeBookmark = NSLocalizedString("Remove Bookmark", comment: "")
         static let bookmarks = NSLocalizedString("Bookmarks", comment: "")
+        static let noDescriptionProvided = NSLocalizedString("No description provided.", comment: "Used when a root comment does not have any contents.")
     }
 }


### PR DESCRIPTION
Fixes #959

Didn't feel completely right to put this in the Model, but couldn't find any other place where this would fit better.