### PR TITLE
More expressive search placeholders

### DIFF
--- a/Classes/Bookmark v2/BookmarkViewController.swift
+++ b/Classes/Bookmark v2/BookmarkViewController.swift
@@ -75,7 +75,7 @@ TabNavRootViewControllerType {
         adapter.dataSource = self
 
         searchBar.delegate = self
-        searchBar.placeholder = Constants.Strings.search
+        searchBar.placeholder = Constants.Strings.searchBookmarks
         searchBar.tintColor = Styles.Colors.Blue.medium.color
         searchBar.backgroundColor = .clear
         searchBar.searchBarStyle = .minimal

--- a/Classes/Search/SearchViewController.swift
+++ b/Classes/Search/SearchViewController.swift
@@ -81,7 +81,7 @@ SearchResultSectionControllerDelegate {
         adapter.dataSource = self
 
         searchBar.delegate = self
-        searchBar.placeholder = Constants.Strings.search
+        searchBar.placeholder = Constants.Strings.searchGitHub
         searchBar.tintColor = Styles.Colors.Blue.medium.color
         searchBar.backgroundColor = .clear
         searchBar.searchBarStyle = .minimal
@@ -180,7 +180,7 @@ SearchResultSectionControllerDelegate {
         case .idle:
             let view = InitialEmptyView(
                 imageName: "search-large",
-                title: NSLocalizedString("Search GitHub", comment: ""),
+                title: Constants.Strings.searchGitHub,
                 description: NSLocalizedString("Find your favorite repositories.\nRecent searches are saved.", comment: "")
             )
             view.delegate = self

--- a/Classes/Views/Constants.swift
+++ b/Classes/Views/Constants.swift
@@ -37,8 +37,8 @@ enum Constants {
         static let bullet = "\u{2022}"
         static let bulletHollow = "\u{25E6}"
         static let search = NSLocalizedString("Search", comment: "")
-        static let searchGitHub = "\(Constants.Strings.search) GitHub"
-        static let searchBookmarks = "\(Constants.Strings.search) \(Constants.Strings.bookmarks)"
+        static let searchGitHub = NSLocalizedString("Search GitHub", comment: "Used as a placeholder for the searchbar when searching for repositories.")
+        static let searchBookmarks = NSLocalizedString("Search Bookmarks", comment: "Used as a placeholder for the searchbar when searching within bookmarks.")
         static let clearAll = NSLocalizedString("Clear All", comment: "")
         static let delete = NSLocalizedString("Delete", comment: "")
         static let inbox = NSLocalizedString("Inbox", comment: "")

--- a/Classes/Views/Constants.swift
+++ b/Classes/Views/Constants.swift
@@ -37,6 +37,8 @@ enum Constants {
         static let bullet = "\u{2022}"
         static let bulletHollow = "\u{25E6}"
         static let search = NSLocalizedString("Search", comment: "")
+        static let searchGitHub = "\(Constants.Strings.search) GitHub"
+        static let searchBookmarks = "\(Constants.Strings.search) \(Constants.Strings.bookmarks)"
         static let clearAll = NSLocalizedString("Clear All", comment: "")
         static let delete = NSLocalizedString("Delete", comment: "")
         static let inbox = NSLocalizedString("Inbox", comment: "")


### PR DESCRIPTION
Fixes #968 
Fixes #969 

This change does not touch the [repository search](https://github.com/rnystrom/GitHawk/blob/search-placeholders/Classes/Repository/RepositoryIssuesViewController.swift#L99); should that be "Search Repository"?

Also does not change the [3D Touch shortcut](https://github.com/rnystrom/GitHawk/blob/search-placeholders/Classes/Systems/ShortcutHandler.swift#L52); should that be "Search GitHub" too?