### PR TITLE
Environment variables and secrets refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,5 +76,6 @@ _site/
 .jekyll-metadata
 
 # secrets
-Resources/env-variables.sh
+tools/env-variables.sh
 Resources/*.xcconfig
+

--- a/.gitignore
+++ b/.gitignore
@@ -77,4 +77,4 @@ _site/
 
 # secrets
 Resources/env-variables.sh
-
+Resources/*.xcconfig

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,5 @@ _site/
 .jekyll-metadata
 
 # secrets
-tools/env-variables.sh
 Resources/*.xcconfig
 

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ node_modules
 _site/
 .sass-cache/
 .jekyll-metadata
+
+# secrets
+Resources/env-variables.sh
+

--- a/Classes/Image Upload/ImgurClient.swift
+++ b/Classes/Image Upload/ImgurClient.swift
@@ -17,7 +17,7 @@ final class ImgurClient {
     }
 
     private static let hostpath = "https://api.imgur.com/3/"
-    private static let headers: HTTPHeaders = ["Authorization": "Client-ID \(ImgurAPI.clientID)"]
+    private static let headers: HTTPHeaders = ["Authorization": "Client-ID \(Secrets.imgurClientID())"]
 
     func request(_ path: String,
                  method: HTTPMethod = .get,

--- a/Classes/Login/GithubClient+AccessToken.swift
+++ b/Classes/Login/GithubClient+AccessToken.swift
@@ -21,8 +21,8 @@ extension GithubClient {
         ) {
         let parameters = [
             "code": code,
-            "client_id": GithubAPI.clientID,
-            "client_secret": GithubAPI.clientSecret
+            "client_id": Secrets.githubClientID(),
+            "client_secret": Secrets.githubClientSecret()
         ]
         let headers = [
             "Accept": "application/json"

--- a/Classes/Login/LoginSplashViewController.swift
+++ b/Classes/Login/LoginSplashViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import SafariServices
 
-private let loginURL = URL(string: "http://github.com/login/oauth/authorize?client_id=\(GithubAPI.clientID)&scope=user+repo+notifications")!
+private let loginURL = URL(string: "http://github.com/login/oauth/authorize?client_id=\(Secrets.githubClientID())&scope=user+repo+notifications")!
 private let callbackURLScheme = "freetime://"
 
 final class LoginSplashViewController: UIViewController, GithubSessionListener {

--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -90,7 +90,7 @@ NewIssueTableViewControllerDelegate {
     // MARK: Private API
 
     func onReviewAccess() {
-        guard let url = URL(string: "https://github.com/settings/connections/applications/\(GithubAPI.clientID)")
+        guard let url = URL(string: "https://github.com/settings/connections/applications/\(Secrets.githubClientID())")
             else { fatalError("Should always create GitHub issue URL") }
         // iOS 11 login uses SFAuthenticationSession which shares credentials with Safari.app
         if #available(iOS 11.0, *) {

--- a/Classes/Systems/Secrets.h
+++ b/Classes/Systems/Secrets.h
@@ -1,0 +1,21 @@
+//
+//  Secrets.h
+//  Freetime
+//
+//  Created by Ryan Nystrom on 11/19/17.
+//  Copyright © 2017 Ryan Nystrom. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Secrets : NSObject
+
++ (NSString *)githubClientID;
++ (NSString *)githubClientSecret;
++ (NSString *)imgurClientID;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Systems/Secrets.m
+++ b/Classes/Systems/Secrets.m
@@ -1,0 +1,27 @@
+//
+//  Secrets.m
+//  Freetime
+//
+//  Created by Ryan Nystrom on 11/19/17.
+//  Copyright © 2017 Ryan Nystrom. All rights reserved.
+//
+
+#import "Secrets.h"
+
+#define STRINGIFY(x) @#x
+
+@implementation Secrets
+
++ (NSString *)githubClientID {
+    return STRINGIFY(GITHUB_CLIENT_ID);
+}
+
++ (NSString *)githubClientSecret {
+    return STRINGIFY(GITHUB_CLIENT_SECRET);
+}
+
++ (NSString *)imgurClientID {
+    return STRINGIFY(IMGUR_CLIENT_ID);
+}
+
+@end

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -193,6 +193,9 @@
 		295840D81EEA0686007723C6 /* IssueCommentQuoteModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295840D71EEA0686007723C6 /* IssueCommentQuoteModel.swift */; };
 		295840DA1EEA07E4007723C6 /* IssueCommentQuoteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295840D91EEA07E4007723C6 /* IssueCommentQuoteCell.swift */; };
 		295A77BE1F75C1CC007BC403 /* RepositoryDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295A77BD1F75C1CC007BC403 /* RepositoryDetails.swift */; };
+		295B51301FC2230700C3993B /* FREETIME-RELEASE.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 295B512D1FC2230600C3993B /* FREETIME-RELEASE.xcconfig */; };
+		295B51311FC2230700C3993B /* FREETIME-TESTFLIGHT.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 295B512E1FC2230600C3993B /* FREETIME-TESTFLIGHT.xcconfig */; };
+		295B51321FC2230700C3993B /* FREETIME-DEBUG.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 295B512F1FC2230600C3993B /* FREETIME-DEBUG.xcconfig */; };
 		295B513C1FC2491800C3993B /* DoubleTappableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B05C01FBFA66200489349 /* DoubleTappableCell.swift */; };
 		295C31C71F09E62600521CED /* NotificationNextPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295C31C61F09E62600521CED /* NotificationNextPageCell.swift */; };
 		295C31C91F09E72D00521CED /* NotificationNextPageSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295C31C81F09E72D00521CED /* NotificationNextPageSectionController.swift */; };
@@ -584,6 +587,9 @@
 		295840D71EEA0686007723C6 /* IssueCommentQuoteModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueCommentQuoteModel.swift; sourceTree = "<group>"; };
 		295840D91EEA07E4007723C6 /* IssueCommentQuoteCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueCommentQuoteCell.swift; sourceTree = "<group>"; };
 		295A77BD1F75C1CC007BC403 /* RepositoryDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetails.swift; sourceTree = "<group>"; };
+		295B512D1FC2230600C3993B /* FREETIME-RELEASE.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "FREETIME-RELEASE.xcconfig"; sourceTree = "<group>"; };
+		295B512E1FC2230600C3993B /* FREETIME-TESTFLIGHT.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "FREETIME-TESTFLIGHT.xcconfig"; sourceTree = "<group>"; };
+		295B512F1FC2230600C3993B /* FREETIME-DEBUG.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "FREETIME-DEBUG.xcconfig"; sourceTree = "<group>"; };
 		295C31C61F09E62600521CED /* NotificationNextPageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationNextPageCell.swift; sourceTree = "<group>"; };
 		295C31C81F09E72D00521CED /* NotificationNextPageSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationNextPageSectionController.swift; sourceTree = "<group>"; };
 		295C31CC1F0AA55400521CED /* IssueStatusEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueStatusEvent.swift; sourceTree = "<group>"; };
@@ -1483,9 +1489,12 @@
 		297AE86D1EC0D5C200B44A1F /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				98F0A0421F27BC4B0062A2CA /* emoji.json */,
 				297AE86E1EC0D5C200B44A1F /* Assets.xcassets */,
+				98F0A0421F27BC4B0062A2CA /* emoji.json */,
 				29FB94391EE767420016E6D4 /* Freetime-Bridging-Header.h */,
+				295B512F1FC2230600C3993B /* FREETIME-DEBUG.xcconfig */,
+				295B512D1FC2230600C3993B /* FREETIME-RELEASE.xcconfig */,
+				295B512E1FC2230600C3993B /* FREETIME-TESTFLIGHT.xcconfig */,
 				297AE8731EC0D5C200B44A1F /* Info.plist */,
 				297AE86F1EC0D5C200B44A1F /* LaunchScreen.storyboard */,
 				29A195061EC7601000C3E289 /* Localizable.stringsdict */,
@@ -1809,6 +1818,7 @@
 			buildConfigurationList = 297AE8511EC0D58A00B44A1F /* Build configuration list for PBXNativeTarget "Freetime" */;
 			buildPhases = (
 				D803031CFB0CF7AEEF2F2B69 /* [CP] Check Pods Manifest.lock */,
+				295B513D1FC250DF00C3993B /* Generate Secrets Xcconfig */,
 				292FCB261EE050F60026635E /* Generate Apollo GraphQL API */,
 				297AE8301EC0D58A00B44A1F /* Sources */,
 				297AE8311EC0D58A00B44A1F /* Frameworks */,
@@ -1904,7 +1914,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				29416BF91F1138B700D03E1A /* OauthLogin.storyboard in Resources */,
+				295B51311FC2230700C3993B /* FREETIME-TESTFLIGHT.xcconfig in Resources */,
 				2919294F1F3F76A20012067B /* Files.storyboard in Resources */,
+				295B51321FC2230700C3993B /* FREETIME-DEBUG.xcconfig in Resources */,
 				297AE8821EC0D5C200B44A1F /* LaunchScreen.storyboard in Resources */,
 				292FF8AC1F2FD3EC009E63F7 /* Settings.storyboard in Resources */,
 				29EE1C171F3A2E7A0046A54D /* Labels.storyboard in Resources */,
@@ -1915,6 +1927,7 @@
 				29A195071EC7601000C3E289 /* Localizable.stringsdict in Resources */,
 				98F9F3FF1F9CCFFE005A0266 /* ImageUpload.storyboard in Resources */,
 				292FF8AA1F2FC3E5009E63F7 /* _notifications.json in Resources */,
+				295B51301FC2230700C3993B /* FREETIME-RELEASE.xcconfig in Resources */,
 				297AE8831EC0D5C200B44A1F /* Main.storyboard in Resources */,
 				292FF8A81F2FC3E5009E63F7 /* authorizations.json in Resources */,
 				98B5A0821F6C73D6000617D6 /* NewIssue.storyboard in Resources */,
@@ -1975,6 +1988,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Fabric/run\" 45ebb3c197db95937d23c07145bb2da8226cd851 5a7c91261f303a0c7b657c8f26d0c46275893eb555f601427d7538e9a67c3b3d";
+		};
+		295B513D1FC250DF00C3993B /* Generate Secrets Xcconfig */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Generate Secrets Xcconfig";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# check if in buddy build environment\nif [[ -z \"$BUDDYBUILD_IPA_PATH\" ]]; then\nexport GITHUB_CLIENT_ID=\"CHANGE_ME\"\nexport GITHUB_CLIENT_SECRET=\"CHANGE_ME\"\nexport IMGUR_CLIENT_ID=\"CHANGE_ME\"\nfi\n\n# assert that all keys are setup\n[ -z \"$GITHUB_CLIENT_ID\" ] && echo \"Need to set GITHUB_CLIENT_ID\" && exit 1;\n[ -z \"$GITHUB_CLIENT_SECRET\" ] && echo \"Need to set GITHUB_CLIENT_SECRET\" && exit 1;\n[ -z \"$IMGUR_CLIENT_ID\" ] && echo \"Need to set IMGUR_CLIENT_ID\" && exit 1;\n\n# setup debug, testflight, and release consts\nSECRETS_PATH=\"Resources/SECRETS.xcconfig\"\nDEBUG_PATH=\"Resources/FREETIME-DEBUG.xcconfig\"\nTESTFLIGHT_PATH=\"Resources/FREETIME-TESTFLIGHT.xcconfig\"\nRELEASE_PATH=\"Resources/FREETIME-RELEASE.xcconfig\"\nPODS_DEBUG=\"#include \\\"Pods/Target Support Files/Pods-Freetime/Pods-Freetime.debug.xcconfig\\\"\"\nPODS_TESTFLIGHT=\"#include \\\"Pods/Target Support Files/Pods-Freetime/Pods-Freetime.testflight.xcconfig\\\"\"\nPODS_RELEASE=\"#include \\\"Pods/Target Support Files/Pods-Freetime/Pods-Freetime.release.xcconfig\\\"\"\n\n# function to write config files\nfunction writeTemplate {\n    echo \"$2\" >> \"$1\"\n    echo \"#include \\\"SECRETS.xcconfig\\\"\" >> \"$1\"\n    echo \" \" >> \"$1\"\n    echo \"GLOBAL_CONSTANTS = GITHUB_CLIENT_ID=\\$(GITHUB_CLIENT_ID) GITHUB_CLIENT_SECRET=\\$(GITHUB_CLIENT_SECRET) IMGUR_CLIENT_ID=\\$(IMGUR_CLIENT_ID)\" >> \"$1\"\n    echo \"GCC_PREPROCESSOR_DEFINITIONS = \\$(inherited) \\$(GLOBAL_CONSTANTS)\" >> \"$1\"\n}\n\n# write the secrets config\nif [ ! -f \"$SECRETS_PATH\" ]; then\necho \"GITHUB_CLIENT_ID=\\\"$GITHUB_CLIENT_ID\\\"\" >> \"$SECRETS_PATH\"\necho \"GITHUB_CLIENT_SECRET=\\\"$GITHUB_CLIENT_SECRET\\\"\" >> \"$SECRETS_PATH\"\necho \"IMGUR_CLIENT_ID=\\\"$IMGUR_CLIENT_ID\\\"\" >> \"$SECRETS_PATH\"\nfi\n\n# write each config file\nif [ ! -f \"$DEBUG_PATH\" ]; then\nwriteTemplate \"$DEBUG_PATH\" \"$PODS_DEBUG\"\nfi\n\nif [ ! -f \"$TESTFLIGHT_PATH\" ]; then\nwriteTemplate \"$TESTFLIGHT_PATH\" \"$PODS_TESTFLIGHT\"\nfi\n\nif [ ! -f \"$RELEASE_PATH\" ]; then\nwriteTemplate \"$RELEASE_PATH\" \"$PODS_RELEASE\"\nfi\n";
 		};
 		46D93019FA5858B5A35F7C0C /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		295B51311FC2230700C3993B /* FREETIME-TESTFLIGHT.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 295B512E1FC2230600C3993B /* FREETIME-TESTFLIGHT.xcconfig */; };
 		295B51321FC2230700C3993B /* FREETIME-DEBUG.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 295B512F1FC2230600C3993B /* FREETIME-DEBUG.xcconfig */; };
 		295B513C1FC2491800C3993B /* DoubleTappableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B05C01FBFA66200489349 /* DoubleTappableCell.swift */; };
+		295B51351FC2306300C3993B /* SECRETS.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 295B51341FC2306300C3993B /* SECRETS.xcconfig */; };
 		295C31C71F09E62600521CED /* NotificationNextPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295C31C61F09E62600521CED /* NotificationNextPageCell.swift */; };
 		295C31C91F09E72D00521CED /* NotificationNextPageSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295C31C81F09E72D00521CED /* NotificationNextPageSectionController.swift */; };
 		295C31CD1F0AA55400521CED /* IssueStatusEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295C31CC1F0AA55400521CED /* IssueStatusEvent.swift */; };
@@ -590,6 +591,7 @@
 		295B512D1FC2230600C3993B /* FREETIME-RELEASE.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "FREETIME-RELEASE.xcconfig"; sourceTree = "<group>"; };
 		295B512E1FC2230600C3993B /* FREETIME-TESTFLIGHT.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "FREETIME-TESTFLIGHT.xcconfig"; sourceTree = "<group>"; };
 		295B512F1FC2230600C3993B /* FREETIME-DEBUG.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "FREETIME-DEBUG.xcconfig"; sourceTree = "<group>"; };
+		295B51341FC2306300C3993B /* SECRETS.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = SECRETS.xcconfig; sourceTree = "<group>"; };
 		295C31C61F09E62600521CED /* NotificationNextPageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationNextPageCell.swift; sourceTree = "<group>"; };
 		295C31C81F09E72D00521CED /* NotificationNextPageSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationNextPageSectionController.swift; sourceTree = "<group>"; };
 		295C31CC1F0AA55400521CED /* IssueStatusEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueStatusEvent.swift; sourceTree = "<group>"; };
@@ -1489,6 +1491,7 @@
 		297AE86D1EC0D5C200B44A1F /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				295B51341FC2306300C3993B /* SECRETS.xcconfig */,
 				297AE86E1EC0D5C200B44A1F /* Assets.xcassets */,
 				98F0A0421F27BC4B0062A2CA /* emoji.json */,
 				29FB94391EE767420016E6D4 /* Freetime-Bridging-Header.h */,
@@ -1917,6 +1920,7 @@
 				295B51311FC2230700C3993B /* FREETIME-TESTFLIGHT.xcconfig in Resources */,
 				2919294F1F3F76A20012067B /* Files.storyboard in Resources */,
 				295B51321FC2230700C3993B /* FREETIME-DEBUG.xcconfig in Resources */,
+				295B51351FC2306300C3993B /* SECRETS.xcconfig in Resources */,
 				297AE8821EC0D5C200B44A1F /* LaunchScreen.storyboard in Resources */,
 				292FF8AC1F2FD3EC009E63F7 /* Settings.storyboard in Resources */,
 				29EE1C171F3A2E7A0046A54D /* Labels.storyboard in Resources */,

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -198,6 +198,7 @@
 		295B51321FC2230700C3993B /* FREETIME-DEBUG.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 295B512F1FC2230600C3993B /* FREETIME-DEBUG.xcconfig */; };
 		295B513C1FC2491800C3993B /* DoubleTappableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B05C01FBFA66200489349 /* DoubleTappableCell.swift */; };
 		295B51351FC2306300C3993B /* SECRETS.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 295B51341FC2306300C3993B /* SECRETS.xcconfig */; };
+		295B51381FC230DE00C3993B /* Secrets.m in Sources */ = {isa = PBXBuildFile; fileRef = 295B51371FC230DE00C3993B /* Secrets.m */; };
 		295C31C71F09E62600521CED /* NotificationNextPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295C31C61F09E62600521CED /* NotificationNextPageCell.swift */; };
 		295C31C91F09E72D00521CED /* NotificationNextPageSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295C31C81F09E72D00521CED /* NotificationNextPageSectionController.swift */; };
 		295C31CD1F0AA55400521CED /* IssueStatusEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295C31CC1F0AA55400521CED /* IssueStatusEvent.swift */; };
@@ -231,7 +232,6 @@
 		297A37301F1704C10081C04E /* IssueRequestSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297A372F1F1704C10081C04E /* IssueRequestSectionController.swift */; };
 		297AE8791EC0D5C200B44A1F /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297AE85F1EC0D5C100B44A1F /* App.swift */; };
 		297AE87A1EC0D5C200B44A1F /* Authorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297AE8601EC0D5C100B44A1F /* Authorization.swift */; };
-		297AE87C1EC0D5C200B44A1F /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297AE8631EC0D5C100B44A1F /* Secrets.swift */; };
 		297AE87E1EC0D5C200B44A1F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297AE8671EC0D5C200B44A1F /* AppDelegate.swift */; };
 		297AE87F1EC0D5C200B44A1F /* UIViewController+Alerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297AE8691EC0D5C200B44A1F /* UIViewController+Alerts.swift */; };
 		297AE8801EC0D5C200B44A1F /* UIViewController+LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297AE86A1EC0D5C200B44A1F /* UIViewController+LoadingIndicator.swift */; };
@@ -592,6 +592,8 @@
 		295B512E1FC2230600C3993B /* FREETIME-TESTFLIGHT.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "FREETIME-TESTFLIGHT.xcconfig"; sourceTree = "<group>"; };
 		295B512F1FC2230600C3993B /* FREETIME-DEBUG.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "FREETIME-DEBUG.xcconfig"; sourceTree = "<group>"; };
 		295B51341FC2306300C3993B /* SECRETS.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = SECRETS.xcconfig; sourceTree = "<group>"; };
+		295B51361FC230DE00C3993B /* Secrets.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Secrets.h; sourceTree = "<group>"; };
+		295B51371FC230DE00C3993B /* Secrets.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Secrets.m; sourceTree = "<group>"; };
 		295C31C61F09E62600521CED /* NotificationNextPageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationNextPageCell.swift; sourceTree = "<group>"; };
 		295C31C81F09E72D00521CED /* NotificationNextPageSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationNextPageSectionController.swift; sourceTree = "<group>"; };
 		295C31CC1F0AA55400521CED /* IssueStatusEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueStatusEvent.swift; sourceTree = "<group>"; };
@@ -633,7 +635,6 @@
 		297AE84E1EC0D58A00B44A1F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		297AE85F1EC0D5C100B44A1F /* App.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		297AE8601EC0D5C100B44A1F /* Authorization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Authorization.swift; sourceTree = "<group>"; };
-		297AE8631EC0D5C100B44A1F /* Secrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
 		297AE8671EC0D5C200B44A1F /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		297AE8691EC0D5C200B44A1F /* UIViewController+Alerts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alerts.swift"; sourceTree = "<group>"; };
 		297AE86A1EC0D5C200B44A1F /* UIViewController+LoadingIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+LoadingIndicator.swift"; sourceTree = "<group>"; };
@@ -1315,7 +1316,6 @@
 				297AE85E1EC0D5C100B44A1F /* Models */,
 				98B5A07E1F6C73A2000617D6 /* New Issue */,
 				29C9FDD91EC6613F00EE3A52 /* Notifications */,
-				297AE8611EC0D5C100B44A1F /* Other */,
 				299A04A61FAE94B4003C2450 /* PullReqeustReviews */,
 				986B872E1F2CA8E800AAB55C /* Repository */,
 				986B87171F2B873200AAB55C /* Search */,
@@ -1360,14 +1360,6 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
-		297AE8611EC0D5C100B44A1F /* Other */ = {
-			isa = PBXGroup;
-			children = (
-				297AE8631EC0D5C100B44A1F /* Secrets.swift */,
-			);
-			path = Other;
-			sourceTree = "<group>";
-		};
 		297AE8641EC0D5C100B44A1F /* Section Controllers */ = {
 			isa = PBXGroup;
 			children = (
@@ -1403,6 +1395,8 @@
 				293189271F5391F700EF0911 /* Result.swift */,
 				29316DC21ECC981D007CAE3F /* RootNavigationManager.swift */,
 				294A3D751FB29843000E81A4 /* ScrollViewKeyboardAdjuster.swift */,
+				295B51361FC230DE00C3993B /* Secrets.h */,
+				295B51371FC230DE00C3993B /* Secrets.m */,
 				3E79A2FE1F8A7DA700E1126B /* ShortcutHandler.swift */,
 				29973E551F68BFDE0004B693 /* Signature.swift */,
 				2971722A1F069E6B005E43AC /* SpinnerSectionController.swift */,
@@ -2270,6 +2264,7 @@
 				DC3238931F9BA29D007DD924 /* SearchQuery.swift in Sources */,
 				7BBFEE5B1F8A8A0400C68E47 /* SearchBarSectionController.swift in Sources */,
 				292FCAFA1EDFCC510026635E /* IssueCommentDetailsViewModel.swift in Sources */,
+				295B51381FC230DE00C3993B /* Secrets.m in Sources */,
 				2949674E1EF9719300B1CF1A /* IssueCommentHrCell.swift in Sources */,
 				2949674C1EF9716400B1CF1A /* IssueCommentHrModel.swift in Sources */,
 				294967531EFC1EDB00B1CF1A /* IssueCommentHtmlCell.swift in Sources */,
@@ -2473,7 +2468,6 @@
 				986B87231F2B98AD00AAB55C /* SearchResultSectionController.swift in Sources */,
 				29AF1E8E1F8ABC900008A0EF /* RepositoryFile.swift in Sources */,
 				986B871D1F2B8FCD00AAB55C /* SearchViewController.swift in Sources */,
-				297AE87C1EC0D5C200B44A1F /* Secrets.swift in Sources */,
 				298BA0971EC947F100B01946 /* SegmentedControlCell.swift in Sources */,
 				297B062C1FB92DCA0026FA23 /* UICollectionViewLayout+Orientation.swift in Sources */,
 				2982ED8B1F95900F00DBF8EB /* GithubClient+EditComment.swift in Sources */,

--- a/Resources/Freetime-Bridging-Header.h
+++ b/Resources/Freetime-Bridging-Header.h
@@ -3,3 +3,4 @@
 //
 
 #import "FlexController.h"
+#import "Secrets.h"


### PR DESCRIPTION
Using #197 as a jumping point, I added a new secrets setup that has:

- Ignored, generated secrets config. Update once, never touch again
- Config files are added to Xcode project file, so CI should build
- Add secrets to buddybuild as env variables

Fixes #986