### PR TITLE
Add initial accessibility support for text cell

### DIFF
--- a/Classes/Issues/Comments/Text/IssueCommentTextCell.swift
+++ b/Classes/Issues/Comments/Text/IssueCommentTextCell.swift
@@ -18,6 +18,7 @@ final class IssueCommentTextCell: DoubleTappableCell, ListBindable, CollapsibleC
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        isAccessibilityElement = true
 
         backgroundColor = .white
         contentView.clipsToBounds = true
@@ -34,6 +35,17 @@ final class IssueCommentTextCell: DoubleTappableCell, ListBindable, CollapsibleC
         layoutContentViewForSafeAreaInsets()
         LayoutCollapsible(layer: overlay, view: contentView)
         textView.reposition(width: contentView.bounds.width)
+    }
+
+    // MARK: Accessibility
+
+    override var accessibilityLabel: String? {
+        get {
+            return contentView.subviews
+                .flatMap { $0.accessibilityLabel }
+                .reduce("", { "\($0 ?? "").\n\($1)" })
+        }
+        set { }
     }
 
     // MARK: ListBindable

--- a/Classes/Views/AttributedStringView.swift
+++ b/Classes/Views/AttributedStringView.swift
@@ -50,6 +50,15 @@ final class AttributedStringView: UIView {
         return true
     }
 
+    // MARK: Accessibility
+
+    override var accessibilityLabel: String? {
+        get {
+            return text?.attributedText.string
+        }
+        set { }
+    }
+
     // MARK: Public API
 
     func reposition(width: CGFloat) {


### PR DESCRIPTION
Fixes #1018.

This adds some simple support for accessibility in the cell. It doesn't yet check if the cell is expandable and offer the option to expand it.
<img width="548" alt="screen shot 2017-11-22 at 10 25 57" src="https://user-images.githubusercontent.com/4190298/33119621-dbd147a6-cf6f-11e7-934f-c6151ae22b39.png">
<img width="545" alt="screen shot 2017-11-22 at 10 25 55" src="https://user-images.githubusercontent.com/4190298/33119622-dbfb1900-cf6f-11e7-85a9-264e5a0e8fe2.png">
