### PR TITLE
Generate accessibility labels for cells

### DIFF
--- a/Classes/Issues/Comments/Reactions/IssueReactionCell.swift
+++ b/Classes/Issues/Comments/Reactions/IssueReactionCell.swift
@@ -134,9 +134,7 @@ final class IssueReactionCell: UICollectionViewCell {
 
     override var accessibilityLabel: String? {
         get {
-            return contentView.subviews
-                .flatMap { $0.accessibilityLabel }
-                .reduce("", { "\($0 ?? "").\n\($1)" })
+            return AccessibilityHelper.generatedLabel(forCell: self)
         }
         set { }
     }

--- a/Classes/Issues/Comments/Text/IssueCommentTextCell.swift
+++ b/Classes/Issues/Comments/Text/IssueCommentTextCell.swift
@@ -41,9 +41,7 @@ final class IssueCommentTextCell: DoubleTappableCell, ListBindable, CollapsibleC
 
     override var accessibilityLabel: String? {
         get {
-            return contentView.subviews
-                .flatMap { $0.accessibilityLabel }
-                .reduce("", { "\($0 ?? "").\n\($1)" })
+            return AccessibilityHelper.generatedLabel(forCell: self)
         }
         set { }
     }

--- a/Classes/Issues/IssueTextActionsView.swift
+++ b/Classes/Issues/IssueTextActionsView.swift
@@ -51,9 +51,8 @@ final class IssueTextActionsCell: SelectableCell {
 
     override var accessibilityLabel: String? {
         get {
-            return contentView.subviews
-                .flatMap { $0.accessibilityLabel }
-                .reduce("", { "\($0 ?? "").\n\($1)" }) }
+            return AccessibilityHelper.generatedLabel(forCell: self)
+        }
         set { }
     }
 

--- a/Classes/Issues/Labels/IssueLabelSummaryCell.swift
+++ b/Classes/Issues/Labels/IssueLabelSummaryCell.swift
@@ -58,9 +58,7 @@ final class IssueLabelSummaryCell: UICollectionViewCell, ListBindable {
     // MARK: Accessibility
     override var accessibilityLabel: String? {
         get {
-            return contentView.subviews
-                .flatMap { $0.accessibilityLabel }
-                .reduce("", { "\($0 ?? "").\n\($1)" })
+            return AccessibilityHelper.generatedLabel(forCell: self)
         }
         set { }
     }

--- a/Classes/Notifications/NotificationCell.swift
+++ b/Classes/Notifications/NotificationCell.swift
@@ -106,9 +106,8 @@ final class NotificationCell: SwipeSelectableCell {
         textLabel.attributedText = viewModel.title.attributedText
         dateLabel.setText(date: viewModel.date)
         reasonImageView.image = viewModel.type.icon.withRenderingMode(.alwaysTemplate)
-        accessibilityLabel = contentView.subviews
-            .flatMap { $0.accessibilityLabel }
-            .reduce("", { "\($0).\n\($1)" })
+        accessibilityLabel = AccessibilityHelper
+            .generatedLabel(forCell: self)
             .appending(".\n\(viewModel.type.localizedString)")
     }
 

--- a/Classes/Notifications/NotificationNextPageCell.swift
+++ b/Classes/Notifications/NotificationNextPageCell.swift
@@ -44,9 +44,7 @@ final class NotificationNextPageCell: UICollectionViewCell {
 
     override var accessibilityLabel: String? {
         get {
-            return contentView.subviews
-                .flatMap { $0.accessibilityLabel }
-                .reduce("", { "\($0 ?? "").\n\($1)" })
+            return AccessibilityHelper.generatedLabel(forCell: self)
         }
         set { }
     }

--- a/Classes/Repository/Empty/RepositoryEmptyResultsCell.swift
+++ b/Classes/Repository/Empty/RepositoryEmptyResultsCell.swift
@@ -55,9 +55,7 @@ final class RepositoryEmptyResultsCell: UICollectionViewCell {
 
     override var accessibilityLabel: String? {
         get {
-            return contentView.subviews
-                .flatMap { $0.accessibilityLabel }
-                .reduce("", { "\($0 ?? "").\n\($1)" })
+            return AccessibilityHelper.generatedLabel(forCell: self)
         }
         set { }
     }

--- a/Classes/Repository/RepositoryCodeDirectoryCellExtension.swift
+++ b/Classes/Repository/RepositoryCodeDirectoryCellExtension.swift
@@ -16,9 +16,8 @@ extension StyledTableCell {
         let fileType = file.isDirectory
             ? NSLocalizedString("Directory", comment: "Used to specify the code cell is a directory.")
             : NSLocalizedString("File", comment: "Used to specify the code cell is a file.")
-        accessibilityLabel = contentView.subviews
-            .flatMap { $0.accessibilityLabel }
-            .reduce("") { "\($0).\n\($1)" }
+        accessibilityLabel = AccessibilityHelper
+            .generatedLabel(forCell: self)
             .appending(".\n\(fileType)")
         accessibilityHint = file.isDirectory
             ? NSLocalizedString("Shows the contents of the directory", comment: "")

--- a/Classes/Repository/RepositorySummaryCell.swift
+++ b/Classes/Repository/RepositorySummaryCell.swift
@@ -114,9 +114,7 @@ final class RepositorySummaryCell: SelectableCell {
 
     override var accessibilityLabel: String? {
         get {
-            return contentView.subviews
-                .flatMap { $0.accessibilityLabel }
-                .reduce("", { "\($0 ?? "").\n\($1)" })
+            return AccessibilityHelper.generatedLabel(forCell: self)
         }
         set { }
     }

--- a/Classes/Search/SearchNoResultsCell.swift
+++ b/Classes/Search/SearchNoResultsCell.swift
@@ -62,9 +62,7 @@ final class SearchNoResultsCell: UICollectionViewCell {
 
     override var accessibilityLabel: String? {
         get {
-            return contentView.subviews
-                .flatMap { $0.accessibilityLabel }
-                .reduce("", { "\($0 ?? "").\n\($1)" })
+            return AccessibilityHelper.generatedLabel(forCell: self)
         }
         set { }
     }

--- a/Classes/Search/SearchRepoResultCell.swift
+++ b/Classes/Search/SearchRepoResultCell.swift
@@ -113,9 +113,7 @@ final class SearchRepoResultCell: SelectableCell {
 
     override var accessibilityLabel: String? {
         get {
-            return contentView.subviews
-                .flatMap { $0.accessibilityLabel }
-                .reduce("", { "\($0 ?? "").\n\($1)" })
+            return AccessibilityHelper.generatedLabel(forCell: self)
         }
         set { }
     }

--- a/Classes/Utility/Accessibility.swift
+++ b/Classes/Utility/Accessibility.swift
@@ -1,0 +1,35 @@
+//
+//  Accessibility.swift
+//  Freetime
+//
+//  Created by Bas Thomas Broek on 22/11/2017.
+//  Copyright © 2017 Ryan Nystrom. All rights reserved.
+//
+
+import Foundation
+
+private protocol ContentViewContaining {
+    var contentView: UIView { get }
+}
+
+extension UICollectionViewCell: ContentViewContaining {}
+extension UITableViewCell: ContentViewContaining {}
+
+enum AccessibilityHelper {
+
+    static func generatedLabel(forCell cell: UICollectionViewCell) -> String {
+        return generatedLabel(forContentViewContainer: cell)
+    }
+
+    static func generatedLabel(forCell cell: UITableViewCell) -> String {
+        return generatedLabel(forContentViewContainer: cell)
+    }
+}
+
+private extension AccessibilityHelper {
+    static func generatedLabel(forContentViewContainer cell: ContentViewContaining) -> String {
+        return cell.contentView.subviews
+            .flatMap { $0.accessibilityLabel }
+            .reduce("") { "\($0).\n\($1)" }
+    }
+}

--- a/Classes/Views/SelectableCell.swift
+++ b/Classes/Views/SelectableCell.swift
@@ -63,9 +63,7 @@ class SelectableCell: UICollectionViewCell {
 
     override var accessibilityLabel: String? {
         get {
-            return contentView.subviews
-                .flatMap { $0.accessibilityLabel }
-                .reduce("", { "\($0 ?? "").\n\($1)" })
+            return AccessibilityHelper.generatedLabel(forCell: self)
         }
         set { }
     }

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 		49FFF4341F9FC83200335568 /* HapticFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FFF4331F9FC83200335568 /* HapticFeedback.swift */; };
 		525C147297BCEEF388B5FDBC /* Pods_Freetime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DB749FB402B660C8A9F516C /* Pods_Freetime.framework */; };
 		54AD5E8E1F24D953004A4BD6 /* FeedSelectionProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54AD5E8D1F24D953004A4BD6 /* FeedSelectionProviding.swift */; };
+		5DB4DD471FC5C10000DF7ABF /* Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB4DD461FC5C10000DF7ABF /* Accessibility.swift */; };
 		754488B11F7ADF8D0032D08C /* UIAlertController+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754488B01F7ADF8D0032D08C /* UIAlertController+Action.swift */; };
 		75468F7A1F7AFBC800F2BC19 /* AlertActionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75468F791F7AFBC800F2BC19 /* AlertActionBuilder.swift */; };
 		75A0ACF51F79A82D0062D99A /* AlertAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A0ACF41F79A82D0062D99A /* AlertAction.swift */; };
@@ -785,6 +786,7 @@
 		49D028FF1F91D90C00E39094 /* ReactionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionTests.swift; sourceTree = "<group>"; };
 		49FFF4331F9FC83200335568 /* HapticFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticFeedback.swift; sourceTree = "<group>"; };
 		54AD5E8D1F24D953004A4BD6 /* FeedSelectionProviding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedSelectionProviding.swift; sourceTree = "<group>"; };
+		5DB4DD461FC5C10000DF7ABF /* Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessibility.swift; sourceTree = "<group>"; };
 		6079633B7825448DA6CAED21 /* Pods-FreetimeTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FreetimeTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-FreetimeTests/Pods-FreetimeTests.debug.xcconfig"; sourceTree = "<group>"; };
 		754488B01F7ADF8D0032D08C /* UIAlertController+Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Action.swift"; sourceTree = "<group>"; };
 		75468F791F7AFBC800F2BC19 /* AlertActionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertActionBuilder.swift; sourceTree = "<group>"; };
@@ -1750,6 +1752,7 @@
 				DC6339361F9F567000402A8D /* DeleteSwipeAction.swift */,
 				DC63393A1F9F65EE00402A8D /* RepositoryAttributedString.swift */,
 				DCA5ED111FAEE3AE0072F074 /* Store.swift */,
+				5DB4DD461FC5C10000DF7ABF /* Accessibility.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -2470,6 +2473,7 @@
 				292ACE1F1F5CB02400C9A02C /* RepositoryEmptyResultsSectionController.swift in Sources */,
 				292ACE1B1F5CAFAD00C9A02C /* RepositoryEmptyResultsType.swift in Sources */,
 				29AF1E881F8AB0AA0008A0EF /* IssueTextActionsView+Markdown.swift in Sources */,
+				5DB4DD471FC5C10000DF7ABF /* Accessibility.swift in Sources */,
 				292ACE181F5C945B00C9A02C /* RepositoryIssueSummaryModel.swift in Sources */,
 				DCA5ED1B1FAEF78B0072F074 /* BookmarkSectionController.swift in Sources */,
 				986B87341F2CAE9800AAB55C /* RepositoryIssueSummaryType.swift in Sources */,


### PR DESCRIPTION
Fixes #1051.

This adds an `AccessibilityHelper` that can be used to generate an accessibility label for either a `UICollectionViewCell` or `UITableViewCell`.