### PR TITLE
Add better error messages for Image Upload fail states

### DIFF
--- a/Classes/Image Upload/ImageUploadTableViewController.swift
+++ b/Classes/Image Upload/ImageUploadTableViewController.swift
@@ -155,10 +155,21 @@ class ImageUploadTableViewController: UITableViewController {
         }
 
         // Check that we have enough "tokens" to actually upload the image
-        client.canUploadImage { [weak self] success in
+        client.canUploadImage { [weak self] error in
             // Ensure that we do have enough tokens, otherwise remove the upload button
-            guard success else {
-                ToastManager.showError(message: NSLocalizedString("Rate Limit reached, cannot upload!", comment: ""))
+            if let error = error as? ImgurClient.ImgurError {
+                
+                switch error {
+                case .endpointError(let response):
+                    ToastManager.showError(message: response)
+                    
+                case .rateLimitExceeded:
+                    ToastManager.showError(message: NSLocalizedString("Rate Limit reached, cannot upload!", comment: ""))
+                    
+                default:
+                    ToastManager.showGenericError()
+                }
+                
                 self?.navigationItem.rightBarButtonItem = nil
                 return
             }

--- a/Classes/Image Upload/ImgurClient.swift
+++ b/Classes/Image Upload/ImgurClient.swift
@@ -14,6 +14,15 @@ final class ImgurClient {
     enum ImgurError: Error {
         // missingLink: - Received a valid response, but no link was available in the payload
         case missingLink
+        
+        // endpointError: - We got an error back from Imgur, where the parameter is their response
+        case endpointError(String)
+        
+        // malformedResponse: - We got a response back from Imgur, but it did not contain values we expected
+        case malformedResponse
+        
+        // rateLimitExceeded: - We are too close to the Imgur rate limit, so no images are being permitted
+        case rateLimitExceeded
     }
 
     private static let hostpath = "https://api.imgur.com/3/"
@@ -39,23 +48,33 @@ final class ImgurClient {
     }
 
     func canUploadImage(
-        completion: @escaping (Bool) -> Void
+        completion: @escaping (Error?) -> Void
         ) {
 
         request("credits") { response in
             guard let dict = response.value as? [String: Any], let data = dict["data"] as? [String: Any] else {
-                completion(false)
+                completion(ImgurError.malformedResponse)
+                return
+            }
+            
+            if let error = data["error"] as? String {
+                completion(ImgurError.endpointError(error))
                 return
             }
 
             guard let userRemaining = data["UserRemaining"] as? Int, let clientRemaining = data["ClientRemaining"] as? Int else {
-                completion(false)
+                completion(ImgurError.malformedResponse)
                 return
             }
 
             // Takes 10 tokens to upload an image, a buffer has been added to prevent us using 100% of our allowance as this
             // will mean our app gets temporarily blocked from Imgur!
-            completion(userRemaining > 20 && clientRemaining > 100)
+            guard userRemaining > 20, clientRemaining > 100 else {
+                completion(ImgurError.rateLimitExceeded)
+                return
+            }
+            
+            completion(nil)
         }
     }
 


### PR DESCRIPTION
Tested on an older version of master before I realised it wasn't the latest code, can't test on latest version of master because #1061 😢 

Fairly simple logic but if we get an error from Imgur we show it straight up with no magic, if it's an error enforced by us we do the rate limit error. If it's an unexpected error we just use a generic one. Atleast we know which path it went down before it failed!

"Invalid client_id" is the current one, seems fair!

fixes #1047 