### PR TITLE
Add repo+author name to action sheet, title accessibility

### DIFF
--- a/Classes/Repository/RepositoryViewController.swift
+++ b/Classes/Repository/RepositoryViewController.swift
@@ -51,8 +51,6 @@ NewIssueTableViewControllerDelegate {
         self.controllers = controllers
 
         super.init(nibName: nil, bundle: nil)
-
-        self.title = "\(repo.owner)/\(repo.name)"
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -77,6 +75,7 @@ NewIssueTableViewControllerDelegate {
 
         configureNavigationItems()
         navigationItem.configure(title: repo.name, subtitle: repo.owner)
+        navigationItem.titleView?.accessibilityLabel = .localizedStringWithFormat("Repository, %@", "\(repo.owner)/\(repo.name)")
     }
 
     // MARK: Private API
@@ -112,7 +111,8 @@ NewIssueTableViewControllerDelegate {
     }
 
     @objc func onMore(sender: UIButton) {
-        let alert = UIAlertController.configured(preferredStyle: .actionSheet)
+        let alertTitle = "\(repo.owner)/\(repo.name)"
+        let alert = UIAlertController.configured(title: alertTitle, preferredStyle: .actionSheet)
 
         weak var weakSelf = self
         let alertBuilder = AlertActionBuilder { $0.rootViewController = weakSelf }


### PR DESCRIPTION
Fixes #1082.

Visual:

<img width="545" alt="screen shot 2017-11-30 at 21 49 18" src="https://user-images.githubusercontent.com/4190298/33455519-9ba63cd2-d61c-11e7-9667-904f041b04b9.png">

Bonus track, as I removed the navigationItem title (it was unused and set in `viewDidLoad()`), I added some more descriptive accessibility there:

<img width="517" alt="screen shot 2017-11-30 at 22 18 36" src="https://user-images.githubusercontent.com/4190298/33455557-be008cf6-d61c-11e7-9518-7f453b32c5b4.png">
<img width="518" alt="screen shot 2017-11-30 at 22 18 40" src="https://user-images.githubusercontent.com/4190298/33455558-be17b75a-d61c-11e7-8a7f-f35710ea6b2e.png">