### PR TITLE
Prevent SLKTextViewController cache from overwriting text

### DIFF
--- a/Classes/Views/TextActionsController.swift
+++ b/Classes/Views/TextActionsController.swift
@@ -74,7 +74,7 @@ final class TextActionsController: NSObject,
     // MARK: ImageUploadDelegate
 
     func imageUploaded(link: String, altText: String) {
-        textView?.replace(left: "![\(altText)](\(link))", right: nil, atLineStart: true)
+        textView?.replace(left: "![\(altText)](\(link))", right: nil, atLineStart: false)
     }
 
 }

--- a/Local Pods/SlackTextViewController/Source/SLKTextViewController.m
+++ b/Local Pods/SlackTextViewController/Source/SLKTextViewController.m
@@ -1904,8 +1904,9 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
             cachedAttributedText = [NSKeyedUnarchiver unarchiveObjectWithData:obj];
         }
     }
-    
-    if (self.textView.attributedText.length == 0 || cachedAttributedText.length > 0) {
+
+    // only update the text if it is empty on the first load
+    if (self.textView.attributedText.length == 0 && cachedAttributedText.length > 0) {
         self.textView.attributedText = cachedAttributedText;
     }
 }


### PR DESCRIPTION
@Sherlouk was spot on!

Fixes #1095

Also changing image insertion to be at the cursor