### PR TITLE
Improve scroll perf of DotListView

### DIFF
--- a/Classes/Issues/Labels/IssueLabelDotCell.swift
+++ b/Classes/Issues/Labels/IssueLabelDotCell.swift
@@ -12,6 +12,16 @@ final class IssueLabelDotCell: UICollectionViewCell {
 
     static let reuse = "cell"
 
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        layer.borderColor = Styles.Colors.Gray.border.color.cgColor
+        layer.borderWidth = 1 / UIScreen.main.scale
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
         layer.cornerRadius = bounds.width/2

--- a/Classes/Views/DotListView.swift
+++ b/Classes/Views/DotListView.swift
@@ -40,7 +40,6 @@ class DotListView: UIView, UICollectionViewDataSource {
     override func layoutSubviews() {
         super.layoutSubviews()
         collectionView.frame = bounds
-        collectionView.reloadData()
     }
 
     // MARK: UICollectionViewDataSource


### PR DESCRIPTION
Noticed the `reloadData` was eating a ton of perf. Also added a border so labels similar to background color are noticeable.