### PR TITLE
Don't scroll beyond the top offset

### DIFF
--- a/Local Pods/SlackTextViewController/Source/SLKTextViewController.m
+++ b/Local Pods/SlackTextViewController/Source/SLKTextViewController.m
@@ -1480,8 +1480,16 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
                                                       CGSize contentSize = scrollView.contentSize;
                                                       CGPoint contentOffset = scrollView.contentOffset;
 
-                                                      CGFloat newOffset = MIN(contentSize.height - scrollViewHeight,
-                                                                              contentOffset.y + keyboardHeight - previousKeyboardHeight);
+                                                      CGFloat topInset = 0;
+                                                      if (@available(iOS 11.0, *)) {
+                                                          topInset = scrollView.adjustedContentInset.top;
+                                                      } else {
+                                                          topInset = scrollView.contentInset.top;
+                                                      }
+
+                                                      CGFloat newOffset = MAX(MIN(contentSize.height - scrollViewHeight,
+                                                                              contentOffset.y + keyboardHeight - previousKeyboardHeight),
+                                                                              -topInset);
 
                                                       scrollView.contentOffset = CGPointMake(contentOffset.x, newOffset);
                                                   }


### PR DESCRIPTION
Stops `SLKTextViewController` from scrolling beyond the top offset when showing the keyboard. There was an issue for this I think? I'll dig it up.