### PR TITLE
Only have a label selected if it actually is

### DIFF
--- a/Classes/Labels/Labels.storyboard
+++ b/Classes/Labels/Labels.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="i6k-yB-d8o">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="i6k-yB-d8o">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -24,11 +24,11 @@
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         </view>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="checkmark" indentationWidth="10" reuseIdentifier="cell" id="3Ru-pe-jei" customClass="LabelTableCell" customModule="Freetime" customModuleProvider="target">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="cell" id="3Ru-pe-jei" customClass="LabelTableCell" customModule="Freetime" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="3Ru-pe-jei" id="JgS-eS-vpS">
-                                    <rect key="frame" x="0.0" y="0.0" width="335" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6I8-5k-y6W">

--- a/Classes/Utility/Accessibility.swift
+++ b/Classes/Utility/Accessibility.swift
@@ -28,8 +28,11 @@ enum AccessibilityHelper {
 
 private extension AccessibilityHelper {
     static func generatedLabel(forContentViewContainer cell: ContentViewContaining) -> String {
-        return cell.contentView.subviews
-            .flatMap { $0.accessibilityLabel }
-            .reduce("") { "\($0).\n\($1)" }
+        let labels = cell.contentView.subviews.flatMap { $0.accessibilityLabel }
+        if labels.count == 1, let label = labels.first {
+            return label
+        } else {
+            return labels.reduce("") { "\($0).\n\($1)" }
+        }
     }
 }


### PR DESCRIPTION
Fixes #1210.

This was weird - we set the checkmark `accessoryType` in the Storyboard, but even if we overwrote it in code VoiceOver would still think it was selected. 🤔

Also return early if a cell only has one accessibility label, to prevent weird unneeded `.\n`s in `accessibilityLabel`s.

(Also thanks for adding the accessibility label @rnystrom, was about to do that!)