### PR TITLE
Add accessibility label and hint to "View Files"

### DIFF
--- a/Classes/Issues/Files/IssueViewFilesCell.swift
+++ b/Classes/Issues/Files/IssueViewFilesCell.swift
@@ -15,6 +15,8 @@ final class IssueViewFilesCell: UICollectionViewCell {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        isAccessibilityElement = true
+        accessibilityTraits |= UIAccessibilityTraitButton
 
         contentView.addSubview(label)
         label.snp.makeConstraints { make in
@@ -59,6 +61,14 @@ final class IssueViewFilesCell: UICollectionViewCell {
             ))
         }
         label.attributedText = attributedText
+        
+        accessibilityLabel = NSLocalizedString(
+            "View Files",
+            comment: "The accessibility label for the View Files button in a pull request.")
+        let hintFormat = NSLocalizedString(
+            "View %zi files with %zi additions and %zi deletions.",
+            comment: "The accessibility hint with details of the View Files button.")
+        accessibilityHint = .localizedStringWithFormat(hintFormat, changes.changedFiles, changes.additions, changes.deletions)
     }
 
 }

--- a/Classes/Issues/Files/IssueViewFilesCell.swift
+++ b/Classes/Issues/Files/IssueViewFilesCell.swift
@@ -68,7 +68,7 @@ final class IssueViewFilesCell: UICollectionViewCell {
         let hintFormat = NSLocalizedString(
             "View %zi files with %zi additions and %zi deletions.",
             comment: "The accessibility hint with details of the View Files button.")
-        accessibilityHint = .localizedStringWithFormat(hintFormat, changes.changedFiles, changes.additions, changes.deletions)
+        accessibilityHint = String(format: hintFormat, arguments: [changes.changedFiles, changes.additions, changes.deletions])
     }
 
 }


### PR DESCRIPTION
Fixes #1239.

Opted to keep it easy ("View Files" as the label) and have the other information in the hint.