### PR TITLE
Add accessibility to milestone cell

### DIFF
--- a/Classes/Issues/Milestone/IssueMilestoneCell.swift
+++ b/Classes/Issues/Milestone/IssueMilestoneCell.swift
@@ -16,6 +16,8 @@ final class IssueMilestoneCell: UICollectionViewCell {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        isAccessibilityElement = true
+        accessibilityTraits |= UIAccessibilityTraitButton
 
         titleLabel.backgroundColor = .clear
         contentView.addSubview(titleLabel)
@@ -60,6 +62,10 @@ final class IssueMilestoneCell: UICollectionViewCell {
         titleLabel.attributedText = titleText
 
         progress.progress = Float(milestone.totalIssueCount - milestone.openIssueCount) / Float(milestone.totalIssueCount)
+
+        let milestoneFormat = NSLocalizedString("Milestone: %@, %.0f percent completed.", comment: "The accessibility label for a repositories' milestone")
+        let percentProgress = progress.progress * 100
+        accessibilityLabel = String(format: milestoneFormat, arguments: [milestone.title, percentProgress])
     }
 
 }


### PR DESCRIPTION
Fixes #1227.

The progress was actually read, but as the cell itself wasn't an accessibility element I didn't catch this. Wrapped the cell and made it more human-“readable”.

<img width="1042" alt="screen shot 2017-12-15 at 21 12 47" src="https://user-images.githubusercontent.com/4190298/34058976-4651baaa-e1dd-11e7-86f6-bce264d39a28.png">
<img width="433" alt="screen shot 2017-12-15 at 21 12 52" src="https://user-images.githubusercontent.com/4190298/34058977-466e9ce2-e1dd-11e7-9626-76defce3bb4a.png">