### PR TITLE
Add + update a11x for navigation titles

### DIFF
--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -109,7 +109,9 @@ FlatCacheListener {
 
         makeBackBarItemEmpty()
 
-        navigationItem.configure(title: "#\(model.number)", subtitle: "\(model.owner)/\(model.repo)")
+        let labelFormat = NSLocalizedString("#%zi in repository %@ by %@", comment: "Accessibility label for an issue/pull request navigation item")
+        let labelString = String(format: labelFormat, arguments: [model.number, model.repo, model.owner])
+        navigationItem.configure(title: "#\(model.number)", subtitle: "\(model.owner)/\(model.repo)", accessibilityLabel: labelString)
 
         feed.viewDidLoad()
         feed.adapter.dataSource = self

--- a/Classes/Models/FilePath.swift
+++ b/Classes/Models/FilePath.swift
@@ -29,7 +29,12 @@ struct FilePath {
     }
 
     var fileExtension: String? {
-        return current?.components(separatedBy: ".").last
+        let components = current?.components(separatedBy: ".") ?? []
+        if components.count > 1 {
+            return components.last
+        } else {
+            return nil
+        }
     }
 
     func appending(_ component: String) -> FilePath {

--- a/Classes/Repository/RepositoryViewController.swift
+++ b/Classes/Repository/RepositoryViewController.swift
@@ -75,8 +75,9 @@ NewIssueTableViewControllerDelegate {
         })
 
         configureNavigationItems()
-        navigationItem.configure(title: repo.name, subtitle: repo.owner)
-        navigationItem.titleView?.accessibilityLabel = .localizedStringWithFormat("Repository, %@", "\(repo.owner)/\(repo.name)")
+        let labelFormat = NSLocalizedString("Repository %@ by %@", comment: "Accessibility label for a repository navigation item")
+        let accessibilityLabel = String(format: labelFormat, arguments: [repo.name, repo.owner])
+        navigationItem.configure(title: repo.name, subtitle: repo.owner, accessibilityLabel: accessibilityLabel)
     }
 
     // MARK: Private API

--- a/Classes/View Controllers/UINavigationItem+TitleSubtitle.swift
+++ b/Classes/View Controllers/UINavigationItem+TitleSubtitle.swift
@@ -11,10 +11,29 @@ import UIKit
 extension UINavigationItem {
 
     func configure(filePath: FilePath) {
-        configure(title: filePath.current, subtitle: filePath.basePath)
+        let accessibilityLabel: String?
+        switch (filePath.current, filePath.basePath) {
+        case (.some(let current), .some(let basePath)):
+            let isCurrentAFile = filePath.fileExtension != nil
+            let currentType = isCurrentAFile ? "File" : "Folder"
+            accessibilityLabel = .localizedStringWithFormat("%@: %@, file path: %@", currentType, current, basePath)
+        case (.some(let current), .none):
+            // NOTE: This is currently unused, as we early-exit
+            // and set the navigationItem's title, but not it's titleView -
+            // and thus we can't set an accessibility label.
+            let isFile = filePath.fileExtension != nil
+            let type = isFile ? "File" : "File path"
+            accessibilityLabel = .localizedStringWithFormat("%@: %@", type, current)
+        case (.none, .some(let basePath)):
+            assert(false, "We should never have just a base path; this should always be accompanied by a current path!")
+            accessibilityLabel = .localizedStringWithFormat("File path: %@", basePath)
+        case (.none, .none):
+            accessibilityLabel = nil
+        }
+        configure(title: filePath.current, subtitle: filePath.basePath, accessibilityLabel: accessibilityLabel)
     }
 
-    func configure(title: String?, subtitle: String?) {
+    func configure(title: String?, subtitle: String?, accessibilityLabel: String? = nil) {
         guard let title = title else { return }
 
         guard let subtitle = subtitle, !subtitle.isEmpty else {
@@ -45,6 +64,9 @@ extension UINavigationItem {
         label.sizeToFit()
 
         titleView = label
+        if let accessibilityLabel = accessibilityLabel { // prevent from setting to nil if we don't provide anything, use default instead
+            titleView?.accessibilityLabel = accessibilityLabel
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #1240 

See the details for screenshots.

Bonus track: A repo already had a special label, but I've updated it to reflect the issue / pull request style (and use the `configure` func to supply the label).
Also fixed the possibility of `fileExtension` returning a folder.

<details>

**Issue / Pull request:**
<img width="433" alt="screen shot 2017-12-15 at 22 56 24" src="https://user-images.githubusercontent.com/4190298/34062903-4aaccc40-e1ef-11e7-91e8-a1b08e7cbc2f.png">
<img width="1042" alt="screen shot 2017-12-15 at 22 56 28" src="https://user-images.githubusercontent.com/4190298/34062904-4ac2df9e-e1ef-11e7-8795-f0c593348a3a.png">

**File + path:**
<img width="433" alt="screen shot 2017-12-15 at 23 21 19" src="https://user-images.githubusercontent.com/4190298/34062905-4ae016fe-e1ef-11e7-8c5e-31e558cd0144.png">
<img width="1042" alt="screen shot 2017-12-15 at 23 21 23" src="https://user-images.githubusercontent.com/4190298/34062906-4af53d68-e1ef-11e7-8318-282fe7f8d9e7.png">

**Path:**
<img width="433" alt="screen shot 2017-12-15 at 23 21 35" src="https://user-images.githubusercontent.com/4190298/34062907-4b0d9e1c-e1ef-11e7-8cf8-1745cf3a831d.png">
<img width="1042" alt="screen shot 2017-12-15 at 23 37 36" src="https://user-images.githubusercontent.com/4190298/34063232-07d19912-e1f1-11e7-9d37-94a2c00518ee.png">

**Repo:**
<img width="433" alt="screen shot 2017-12-15 at 23 24 55" src="https://user-images.githubusercontent.com/4190298/34062909-4b3ac27a-e1ef-11e7-924e-d404ac442ef1.png">
<img width="1042" alt="screen shot 2017-12-15 at 23 24 58" src="https://user-images.githubusercontent.com/4190298/34062910-4b550554-e1ef-11e7-95f9-8d41d0315aa7.png">
</details>