### PR TITLE
Change version of apollo-codegen to exactly match 0.17.0-alpha.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "apollo-codegen": "^0.17.0-alpha.13"
+    "apollo-codegen": "0.17.0-alpha.13"
   }
 }


### PR DESCRIPTION
When i cloned the repo and ran `npm install`, the version of apollo-codegen that npm installed on my machine was `0.17.2`. That version generated [this API.swift file](https://gist.github.com/spsjvc/6d93b02c9d09932f9ec3a99554bf7cc0) which is different than the one on `master` and breaks the build. The exact 0.17.0-alpha.13 of apollo-codegen works fine. This might be a temporary fix until the app is updated to work with the newer versions.