### PR TITLE
View notifications by repository

### DIFF
--- a/Classes/Notifications/NotificationClient.swift
+++ b/Classes/Notifications/NotificationClient.swift
@@ -56,7 +56,7 @@ final class NotificationClient {
 
         let path: String
         if let repo = repo {
-            path = "/repos/\(repo.owner)/\(repo.name)/notifications"
+            path = "repos/\(repo.owner)/\(repo.name)/notifications"
         } else {
             path = "notifications"
         }
@@ -157,7 +157,7 @@ final class NotificationClient {
         let path: String
         if let repo = repo {
             // https://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository
-            path = "/repos/\(repo.owner)/\(repo.name)/notifications"
+            path = "repos/\(repo.owner)/\(repo.name)/notifications"
         } else {
             // https://developer.github.com/v3/activity/notifications/#mark-as-read
             path = "notifications"

--- a/Classes/Notifications/NotificationClient.swift
+++ b/Classes/Notifications/NotificationClient.swift
@@ -123,4 +123,28 @@ final class NotificationClient {
         })
     }
 
+    func fetchWatchedRepositories(completion: @escaping (Result<[Repository]>) -> Void) {
+        guard let viewer = githubClient.userSession?.username else {
+            completion(.error(nil))
+            return
+        }
+
+        githubClient.request(GithubClient.Request(
+            path: "users/\(viewer)/subscriptions"
+        ) { (response, _) in
+            // https://developer.github.com/v3/activity/watching/#list-repositories-being-watched
+            if let jsonArr = response.value as? [ [String: Any] ] {
+                var repos = [Repository]()
+                for json in jsonArr {
+                    if let repo = Repository(json: json) {
+                        repos.append(repo)
+                    }
+                }
+                completion(.success(repos))
+            } else {
+                completion(.error(response.error))
+            }
+        })
+    }
+
 }

--- a/Classes/Notifications/NotificationClient.swift
+++ b/Classes/Notifications/NotificationClient.swift
@@ -144,7 +144,7 @@ final class NotificationClient {
                         repos.append(repo)
                     }
                 }
-                completion(.success(repos))
+                completion(.success(repos.sorted { $0.name < $1.name }))
             } else {
                 completion(.error(response.error))
             }

--- a/Classes/Notifications/NotificationSubscriptionsController.swift
+++ b/Classes/Notifications/NotificationSubscriptionsController.swift
@@ -1,0 +1,74 @@
+//
+//  NotificationSubscriptionsController.swift
+//  Freetime
+//
+//  Created by Ryan Nystrom on 12/18/17.
+//  Copyright © 2017 Ryan Nystrom. All rights reserved.
+//
+
+import UIKit
+
+final class NotificationSubscriptionsController {
+
+    enum State {
+        case loading
+        case results([Repository])
+        case error
+    }
+
+    private weak var viewController: UIViewController?
+    private let client: NotificationClient
+    private var state: State = .loading
+
+    init(viewController: UIViewController, client: NotificationClient) {
+        self.viewController = viewController
+        self.client = client
+        self.refreshSubscriptions()
+    }
+
+    // MARK: Public API
+
+    var actions: [UIAlertAction] {
+        switch state {
+        case .loading: return []
+        case .error: return [refreshAction]
+        case .results(let repos): return repoActions(repos: repos)
+        }
+    }
+
+    // MARK: Private API
+
+    var refreshAction: UIAlertAction {
+        return UIAlertAction(
+            title: NSLocalizedString("Refresh", comment: ""),
+            style: .default,
+            handler: { [weak self] _ in
+                self?.refreshSubscriptions()
+        })
+    }
+
+    func repoActions(repos: [Repository]) -> [UIAlertAction] {
+        return repos.map {
+            let name = $0.name
+            return UIAlertAction(title: name, style: .default, handler: { [weak self] _ in
+                self?.pushRepoNotifications(name: name)
+            })
+        }
+    }
+
+    func pushRepoNotifications(name: String) {
+        // TODO
+    }
+
+    func refreshSubscriptions() {
+        client.fetchWatchedRepositories { [weak self] result in
+            switch result {
+            case .success(let repos): self?.state = .results(repos)
+            case .error:
+                self?.state = .error
+                ToastManager.showGenericError()
+            }
+        }
+    }
+
+}

--- a/Classes/Notifications/NotificationsViewController.swift
+++ b/Classes/Notifications/NotificationsViewController.swift
@@ -64,7 +64,7 @@ FlatCacheListener {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        resetLeftBarItem()
+        resetRightBarItem()
 
         switch inboxType {
         case .unread:
@@ -104,7 +104,7 @@ FlatCacheListener {
         navigationController?.pushViewController(controller, animated: trueUnlessReduceMotionEnabled)
     }
 
-    func resetLeftBarItem() {
+    func resetRightBarItem() {
         let item = UIBarButtonItem(
             image: UIImage(named: "check"),
             style: .plain,
@@ -131,7 +131,7 @@ FlatCacheListener {
     }
 
     private func markAllRead() {
-        self.setLeftBarItemSpinning()
+        self.setRightBarItemSpinning()
         self.client.markAllNotifications { success in
             let generator = UINotificationFeedbackGenerator()
             if success {
@@ -181,7 +181,7 @@ FlatCacheListener {
         }
 
         // set after updating so self.models has already been changed
-        self.resetLeftBarItem()
+        self.resetRightBarItem()
     }
 
     private func rebuildAndUpdate(

--- a/Classes/Notifications/NotificationsViewController.swift
+++ b/Classes/Notifications/NotificationsViewController.swift
@@ -201,6 +201,8 @@ FlatCacheListener {
     // MARK: Overrides
 
     override func fetch(page: NSNumber?) {
+        subscriptionController?.fetchSubscriptions()
+
         let width = view.bounds.width
 
         let repo: (String, String)?
@@ -208,7 +210,7 @@ FlatCacheListener {
         switch inboxType {
         case .repo(let owner, let name):
             repo = (owner, name)
-            fetchAll = false
+            fetchAll = true
         case .all:
             repo = nil
             fetchAll = true

--- a/Classes/Notifications/NotificationsViewController.swift
+++ b/Classes/Notifications/NotificationsViewController.swift
@@ -130,7 +130,7 @@ FlatCacheListener {
         BadgeNotifications.update(count: count)
     }
 
-    private func markAllRead() {
+    private func markRead() {
         self.setRightBarItemSpinning()
 
         let block: (Bool) -> Void = { success in
@@ -156,15 +156,27 @@ FlatCacheListener {
     }
 
     @objc private func onMarkAll() {
+        let message: String
+        switch inboxType {
+        case .all, .unread:
+            message = NSLocalizedString("Mark all notifications as read?", comment: "")
+        case .repo(_, let name):
+            let messageFormat = NSLocalizedString("Mark %@ notifications as read?", comment: "")
+            message = String(format: messageFormat, name)
+        }
+
         let alert = UIAlertController.configured(
             title: NSLocalizedString("Notifications", comment: ""),
-            message: NSLocalizedString("Mark all notifications as read?", comment: ""),
+            message: message,
             preferredStyle: .alert
         )
 
         alert.addActions([
-            AlertAction.markAll({ [weak self] _ in
-                self?.markAllRead()
+            UIAlertAction(
+                title: NSLocalizedString("Mark Read", comment: ""),
+                style: .destructive,
+                handler: { [weak self] _ in
+                    self?.markRead()
             }),
             AlertAction.cancel()
         ])

--- a/Classes/Notifications/NotificationsViewController.swift
+++ b/Classes/Notifications/NotificationsViewController.swift
@@ -132,7 +132,8 @@ FlatCacheListener {
 
     private func markAllRead() {
         self.setRightBarItemSpinning()
-        self.client.markAllNotifications { success in
+
+        let block: (Bool) -> Void = { success in
             let generator = UINotificationFeedbackGenerator()
             if success {
                 generator.notificationOccurred(.success)
@@ -146,6 +147,11 @@ FlatCacheListener {
 
             // "mark all" is an engaging action, system prompt on it
             RatingController.prompt(.system)
+        }
+
+        switch inboxType {
+        case .all, .unread: client.markAllNotifications(completion: block)
+        case .repo(let owner, let name): client.markRepoNotifications(owner: owner, repo: name, completion: block)
         }
     }
 

--- a/Classes/Utility/AlertAction.swift
+++ b/Classes/Utility/AlertAction.swift
@@ -100,10 +100,6 @@ struct AlertAction {
         return UIAlertAction(title: Constants.Strings.signin, style: .default, handler: handler)
     }
 
-    static func markAll(_ handler: AlertActionBlock? = nil) -> UIAlertAction {
-        return UIAlertAction(title: NSLocalizedString("Mark all Read", comment: ""), style: .destructive, handler: handler)
-    }
-
     static func clearAll(_ handler: AlertActionBlock? = nil) -> UIAlertAction {
         return UIAlertAction(title: Constants.Strings.clearAll, style: .destructive, handler: handler)
     }

--- a/Classes/View Controllers/RootViewControllers.swift
+++ b/Classes/View Controllers/RootViewControllers.swift
@@ -30,7 +30,7 @@ func newSettingsRootViewController(
 }
 
 func newNotificationsRootViewController(client: GithubClient) -> UIViewController {
-    let controller = NotificationsViewController(client: NotificationClient(githubClient: client), showRead: false)
+    let controller = NotificationsViewController(client: NotificationClient(githubClient: client), inboxType: .unread)
     let title = NSLocalizedString("Inbox", comment: "")
     controller.title = title
     let nav = UINavigationController(rootViewController: controller)

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		294563EE1EE5012900DBCD35 /* PullRequest+IssueType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294563ED1EE5012900DBCD35 /* PullRequest+IssueType.swift */; };
 		294563F01EE5036A00DBCD35 /* IssueType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294563EF1EE5036A00DBCD35 /* IssueType.swift */; };
 		29459A6F1FE61E0500034A04 /* MarkdownCheckboxModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29459A6E1FE61E0500034A04 /* MarkdownCheckboxModel.swift */; };
+		29459A731FE853C600034A04 /* NotificationSubscriptionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29459A721FE853C600034A04 /* NotificationSubscriptionsController.swift */; };
 		2949674C1EF9716400B1CF1A /* IssueCommentHrModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2949674B1EF9716400B1CF1A /* IssueCommentHrModel.swift */; };
 		2949674E1EF9719300B1CF1A /* IssueCommentHrCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2949674D1EF9719300B1CF1A /* IssueCommentHrCell.swift */; };
 		294967511EFC1E9E00B1CF1A /* IssueCommentHtmlModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294967501EFC1E9E00B1CF1A /* IssueCommentHtmlModel.swift */; };
@@ -544,6 +545,7 @@
 		294563ED1EE5012900DBCD35 /* PullRequest+IssueType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PullRequest+IssueType.swift"; sourceTree = "<group>"; };
 		294563EF1EE5036A00DBCD35 /* IssueType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueType.swift; sourceTree = "<group>"; };
 		29459A6E1FE61E0500034A04 /* MarkdownCheckboxModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCheckboxModel.swift; sourceTree = "<group>"; };
+		29459A721FE853C600034A04 /* NotificationSubscriptionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSubscriptionsController.swift; sourceTree = "<group>"; };
 		2949674B1EF9716400B1CF1A /* IssueCommentHrModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCommentHrModel.swift; sourceTree = "<group>"; };
 		2949674D1EF9719300B1CF1A /* IssueCommentHrCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCommentHrCell.swift; sourceTree = "<group>"; };
 		294967501EFC1E9E00B1CF1A /* IssueCommentHtmlModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCommentHtmlModel.swift; sourceTree = "<group>"; };
@@ -1590,6 +1592,7 @@
 				29A195101EC7AC9500C3E289 /* NotificationRepoCell.swift */,
 				291929681F40EEBD0012067B /* NotificationsDataSource.swift */,
 				2980E0911F073E8B000E02C6 /* NotificationSectionController.swift */,
+				29459A721FE853C600034A04 /* NotificationSubscriptionsController.swift */,
 				29EEB22C1F9BF65B00AB237B /* NotificationsViewController.swift */,
 				29A1950B1EC7901400C3E289 /* NotificationType.swift */,
 				29A195091EC78B4800C3E289 /* NotificationType+Icon.swift */,
@@ -2496,6 +2499,7 @@
 				293971891F904C82002FAC4B /* Toast.swift in Sources */,
 				297FB7781F51128A00F2E618 /* SettingsAccountsViewController.swift in Sources */,
 				292FF8AE1F2FD4A8009E63F7 /* SettingsViewController.swift in Sources */,
+				29459A731FE853C600034A04 /* NotificationSubscriptionsController.swift in Sources */,
 				29EE444A1F19D85800B05ED3 /* ShowErrorStatusBar.swift in Sources */,
 				295840711EE9F4D3007723C6 /* ShowMoreDetailsLabel+Date.swift in Sources */,
 				29CF01D31FDDA1EE0084B66F /* NotificationEmptyMessageClient.swift in Sources */,


### PR DESCRIPTION
- New left/right nav bar items for inbox
- Show alert, select repo
- `NotificationsViewController` now handles unread, all, and repo (show all for repo)
- "Mark Read" for repo clears _only_ that repo's notifications

Pretty happy w/ this quick hack. Been using it all night. This will get us some immediate feedback before investing much in custom UI controls (e.g. the whole nav-bar dropdown thing).

Fixes #61 

![img_0554](https://user-images.githubusercontent.com/739696/34138381-2eef8664-e43d-11e7-9f7d-02634c175e51.jpg)

![img_0555](https://user-images.githubusercontent.com/739696/34138382-2efdcf12-e43d-11e7-82ae-b51c61f355ba.jpg)
