### PR TITLE
[DO NOT MERGE] Switch markAll logic back to mark all

### DIFF
--- a/Classes/Notifications/NotificationsViewController.swift
+++ b/Classes/Notifications/NotificationsViewController.swift
@@ -129,7 +129,7 @@ FlatCacheListener {
         if let markAllItem = markAllItem {
             assert(markAllItem.action == #selector(onMarkAll)) // https://github.com/rnystrom/GitHawk/issues/1293
         }
-        markAllItem?.isEnabled = false//hasUnread
+        markAllItem?.isEnabled = hasUnread
         navigationController?.tabBarItem.badgeValue = hasUnread ? "\(count)" : nil
         BadgeNotifications.update(count: count)
     }

--- a/Classes/Notifications/NotificationsViewController.swift
+++ b/Classes/Notifications/NotificationsViewController.swift
@@ -109,7 +109,7 @@ FlatCacheListener {
             image: UIImage(named: "check"),
             style: .plain,
             target: self,
-            action: #selector(NotificationsViewController.onMarkAll)
+            action: #selector(onMarkAll)
         )
         item.accessibilityLabel = NSLocalizedString("Mark notifications read", comment: "")
         navigationItem.rightBarButtonItem = item
@@ -125,7 +125,11 @@ FlatCacheListener {
         }
 
         let hasUnread = count > 0
-        navigationItem.leftBarButtonItem?.isEnabled = hasUnread
+        let markAllItem = navigationItem.rightBarButtonItem
+        if let markAllItem = markAllItem {
+            assert(markAllItem.action == #selector(onMarkAll)) // https://github.com/rnystrom/GitHawk/issues/1293
+        }
+        markAllItem?.isEnabled = false//hasUnread
         navigationController?.tabBarItem.badgeValue = hasUnread ? "\(count)" : nil
         BadgeNotifications.update(count: count)
     }


### PR DESCRIPTION
Fixes #1293 

Added the Do Not Merge as there is something super strange happening I can't explain - when refreshing, the mark all is enabled for a split second. Seems to happen in [`IGListAdapter`'s `performUpdatesAnimated`](https://github.com/Instagram/IGListKit/blob/master/Source/IGListAdapter.m#L330), called by the feed's `finishLoading`.

@rnystrom, what am I overlooking?