### PR TITLE
Rename .all title to `Archived`

### DIFF
--- a/Classes/Notifications/NotificationsViewController.swift
+++ b/Classes/Notifications/NotificationsViewController.swift
@@ -48,7 +48,7 @@ FlatCacheListener {
 
         switch inboxType {
         case .all:
-            title = NSLocalizedString("Archives", comment: "")
+            title = NSLocalizedString("Archived", comment: "")
         case .unread:
             title = NSLocalizedString("Inbox", comment: "")
             self.subscriptionController = NotificationSubscriptionsController(viewController: self, client: client)


### PR DESCRIPTION
This is more consistent since we have `View Archived` here https://github.com/rnystrom/GitHawk/blob/b9cda654a9caab61b7b690ca3bceefba240636a8/Classes/Notifications/NotificationsViewController.swift#L91