### PR TITLE
Add another manage button at the bottom of timeline

### DIFF
--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -24,7 +24,8 @@ final class IssuesViewController: MessageViewController,
     FlatCacheListener,
     MessageViewControllerAutocompleteDelegate,
     UITableViewDelegate,
-UITableViewDataSource {
+UITableViewDataSource,
+IssueManagingSectionControllerDelegate {
 
     private let client: GithubClient
     private let model: IssueDetailsModel
@@ -330,7 +331,11 @@ UITableViewDataSource {
         var objects: [ListDiffable] = [current.status]
 
         if viewerIsCollaborator {
-            objects.append(IssueManagingModel(objectId: current.id, pullRequest: current.pullRequest))
+            objects.append(IssueManagingModel(
+                objectId: current.id,
+                pullRequest: current.pullRequest,
+                position: .top
+            ))
         }
 
         objects.append(current.title)
@@ -360,6 +365,14 @@ UITableViewDataSource {
 
         objects += current.timelineViewModels
 
+        if viewerIsCollaborator {
+            objects.append(IssueManagingModel(
+                objectId: current.id,
+                pullRequest: current.pullRequest,
+                position: .bottom
+            ))
+        }
+
         return objects
     }
 
@@ -383,7 +396,7 @@ UITableViewDataSource {
         case is IssueNeckLoadModel: return IssueNeckLoadSectionController(delegate: self)
         case is Milestone: return IssueMilestoneSectionController(issueModel: model)
         case is IssueFileChangesModel: return IssueViewFilesSectionController(issueModel: model, client: client)
-        case is IssueManagingModel: return IssueManagingSectionController(model: model, client: client)
+        case is IssueManagingModel: return IssueManagingSectionController(model: model, client: client, delegate: self)
         default: fatalError("Unhandled object: \(object)")
         }
     }
@@ -508,6 +521,12 @@ UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return autocomplete.cellHeight
+    }
+
+    // MARK: IssueManagingSectionControllerDelegate
+
+    func needsScrollToBottom(sectionController: IssueManagingSectionController) {
+        collectionView.scrollToBottom(animated: true)
     }
 
 }

--- a/Classes/Issues/Managing/IssueManagingModel.swift
+++ b/Classes/Issues/Managing/IssueManagingModel.swift
@@ -11,19 +11,26 @@ import IGListKit
 
 final class IssueManagingModel: ListDiffable {
 
+    enum ManagingPosition: Int {
+        case top
+        case bottom
+    }
+
     let objectId: String
     let pullRequest: Bool
+    let position: ManagingPosition
 
-    init(objectId: String, pullRequest: Bool) {
+    init(objectId: String, pullRequest: Bool, position: ManagingPosition) {
         self.objectId = objectId
         self.pullRequest = pullRequest
+        self.position = position
     }
 
     // MARK: ListDiffable
 
     func diffIdentifier() -> NSObjectProtocol {
         // should only ever be one
-        return "managing_model" as NSObjectProtocol
+        return "managing_model\(position)" as NSObjectProtocol
     }
 
     func isEqual(toDiffableObject object: ListDiffable?) -> Bool {

--- a/Classes/Views/UIScrollView+ScrollToBottom.swift
+++ b/Classes/Views/UIScrollView+ScrollToBottom.swift
@@ -11,9 +11,13 @@ import UIKit
 extension UIScrollView {
 
     func scrollToBottom(animated: Bool) {
-        let inset = contentInset
         let contentHeight = contentSize.height
         let viewportHeight = bounds.height
+
+        // make sure not already at the top
+        guard contentHeight > viewportHeight else { return }
+
+        let inset = contentInset
         let offset = contentHeight - inset.bottom + inset.top - viewportHeight
         setContentOffset(CGPoint(x: 0, y: offset), animated: animated)
     }


### PR DESCRIPTION
Fixes #1322

Responding to feedback from @orta that the auto scroll-to-bottom (opening an issue/PR from a notification) can be frustrating b/c you have to scroll back to the top to manage stuff.

Simple-thing-first, let's try out a manage button on the bottom.

A few things:

- Added a delegate so that it scrolls again when expanded (showing the actions)
- When there is very little content, it looks a little silly

![simulator screen shot - iphone x - 2017-12-31 at 18 38 16](https://user-images.githubusercontent.com/739696/34464764-307b1e06-ee5d-11e7-8408-cdda05ddc4ee.png)

![simulator screen shot - iphone x - 2017-12-31 at 18 38 18](https://user-images.githubusercontent.com/739696/34464765-308379f2-ee5d-11e7-91b5-d42217d0d66f.png)

![simulator screen shot - iphone x - 2017-12-31 at 18 39 45](https://user-images.githubusercontent.com/739696/34464766-308cb580-ee5d-11e7-9f2b-16e65514e366.png)