### PR TITLE
Manage button scrolls to bottom to reveal actions

### DIFF
--- a/Classes/Issues/Managing/IssueManagingNavSectionController.swift
+++ b/Classes/Issues/Managing/IssueManagingNavSectionController.swift
@@ -1,0 +1,44 @@
+//
+//  IssueManagingNavSectionController.swift
+//  Freetime
+//
+//  Created by Ryan Nystrom on 1/1/18.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import UIKit
+import IGListKit
+
+protocol IssueManagingNavSectionControllerDelegate: class {
+    func didSelect(managingNavController: IssueManagingNavSectionController)
+}
+
+final class IssueManagingNavSectionController: ListSectionController {
+
+    private weak var delegate: IssueManagingNavSectionControllerDelegate?
+
+    init(delegate: IssueManagingNavSectionControllerDelegate) {
+        self.delegate = delegate
+    }
+
+    override func sizeForItem(at index: Int) -> CGSize {
+        guard let containerWidth = collectionContext?.containerSize.width
+            else { fatalError("Collection context must be set") }
+        return CGSize(
+            width: floor(containerWidth / 2),
+            height: Styles.Sizes.labelEventHeight
+        )
+    }
+
+    override func cellForItem(at index: Int) -> UICollectionViewCell {
+        guard let cell = collectionContext?.dequeueReusableCell(of: IssueManagingExpansionCell.self, for: self, at: index) as? IssueManagingExpansionCell
+            else { fatalError("Cannot dequeue cell") }
+        return cell
+    }
+
+    override func didSelectItem(at index: Int) {
+        collectionContext?.deselectItem(at: index, sectionController: self, animated: true)
+        delegate?.didSelect(managingNavController: self)
+    }
+
+}

--- a/Classes/Issues/Managing/IssueManagingSectionController.swift
+++ b/Classes/Issues/Managing/IssueManagingSectionController.swift
@@ -199,12 +199,17 @@ PeopleViewControllerDelegate {
         ) -> CGSize {
         guard let containerWidth = collectionContext?.containerSize.width
             else { fatalError("Collection context must be set") }
-        // justify-align cells to a max of 4-per-row
-        let itemsPerRow = CGFloat(min(self.viewModels.count - 1, 4))
-        let width = floor(containerWidth / itemsPerRow)
+
+        let height = IssueManagingActionCell.height
+        let width = HangingChadItemWidth(
+            index: index,
+            count: viewModels.count,
+            containerWidth: containerWidth,
+            desiredItemWidth: height
+        )
         return CGSize(
             width: width,
-            height: IssueManagingActionCell.height
+            height: height
         )
     }
 

--- a/Classes/Views/HangingChadItemWidth.swift
+++ b/Classes/Views/HangingChadItemWidth.swift
@@ -1,0 +1,36 @@
+//
+//  HangingChadItemWidth.swift
+//  Freetime
+//
+//  Created by Ryan Nystrom on 1/1/18.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import UIKit
+
+func HangingChadItemWidth(
+    index: Int,
+    count: Int,
+    containerWidth: CGFloat,
+    desiredItemWidth: CGFloat
+    ) -> CGFloat {
+    guard count > 0, index < count else { return 0 }
+
+    let maxPerRow = Int(floor(containerWidth / desiredItemWidth))
+    let itemsPerRow = min(count, maxPerRow)
+
+    let fullRows = count / itemsPerRow
+    let fullRowsCount = fullRows * itemsPerRow
+    let remainder = count - fullRowsCount
+
+    let itemsInThisRow: Int
+    if remainder == 1 && count > 2 && itemsPerRow > 1 && index > count - 3 {
+        itemsInThisRow = 2
+    } else if index > fullRowsCount - 1 {
+        itemsInThisRow = remainder
+    } else {
+        itemsInThisRow = itemsPerRow
+    }
+
+    return floor(containerWidth / CGFloat(itemsInThisRow))
+}

--- a/Classes/Views/HangingChadItemWidth.swift
+++ b/Classes/Views/HangingChadItemWidth.swift
@@ -24,8 +24,19 @@ func HangingChadItemWidth(
     let remainder = count - fullRowsCount
 
     let itemsInThisRow: Int
-    if remainder == 1 && count > 2 && itemsPerRow > 1 && index > count - 3 {
-        itemsInThisRow = 2
+    if remainder == 1 && count > 2 && itemsPerRow > 1 {
+        let row = index / itemsPerRow
+        if row == fullRows {
+            itemsInThisRow = 2
+        } else if row == fullRows - 1 {
+            if index == count - 2 {
+                itemsInThisRow = 2
+            } else {
+                itemsInThisRow = itemsPerRow - 1
+            }
+        } else {
+            itemsInThisRow = itemsPerRow
+        }
     } else if index > fullRowsCount - 1 {
         itemsInThisRow = remainder
     } else {

--- a/Classes/Views/UIScrollView+ScrollToBottom.swift
+++ b/Classes/Views/UIScrollView+ScrollToBottom.swift
@@ -11,9 +11,13 @@ import UIKit
 extension UIScrollView {
 
     func scrollToBottom(animated: Bool) {
-        let inset = contentInset
         let contentHeight = contentSize.height
         let viewportHeight = bounds.height
+
+        // make sure not already at the top
+        guard contentHeight > viewportHeight else { return }
+
+        let inset = contentInset
         let offset = contentHeight - inset.bottom + inset.top - viewportHeight
         setContentOffset(CGPoint(x: 0, y: offset), animated: animated)
     }

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -196,6 +196,9 @@
 		297406A11F0EE51E003A6BFB /* MMElement+Table.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297406A01F0EE51E003A6BFB /* MMElement+Table.swift */; };
 		29764C141FDC4DB60095FF95 /* SettingsLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29764C131FDC4DB60095FF95 /* SettingsLabel.swift */; };
 		29792B1D1FFB2FC6007A0C57 /* IssueManagingNavSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29792B1C1FFB2FC6007A0C57 /* IssueManagingNavSectionController.swift */; };
+		29792B1F1FFB3E3A007A0C57 /* HangingChadItemWidth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29792B1E1FFB3E3A007A0C57 /* HangingChadItemWidth.swift */; };
+		29792B221FFB3EE8007A0C57 /* HangingChadItemWidth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29792B1E1FFB3E3A007A0C57 /* HangingChadItemWidth.swift */; };
+		29792B241FFB3EF6007A0C57 /* HangingChadItemWidthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29792B231FFB3EF6007A0C57 /* HangingChadItemWidthTests.swift */; };
 		297A372C1F1700BC0081C04E /* IssueRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297A372B1F1700BC0081C04E /* IssueRequestModel.swift */; };
 		297A372E1F17018F0081C04E /* IssueRequestCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297A372D1F17018F0081C04E /* IssueRequestCell.swift */; };
 		297A37301F1704C10081C04E /* IssueRequestSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297A372F1F1704C10081C04E /* IssueRequestSectionController.swift */; };
@@ -608,6 +611,8 @@
 		297406A01F0EE51E003A6BFB /* MMElement+Table.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MMElement+Table.swift"; sourceTree = "<group>"; };
 		29764C131FDC4DB60095FF95 /* SettingsLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsLabel.swift; sourceTree = "<group>"; };
 		29792B1C1FFB2FC6007A0C57 /* IssueManagingNavSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueManagingNavSectionController.swift; sourceTree = "<group>"; };
+		29792B1E1FFB3E3A007A0C57 /* HangingChadItemWidth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangingChadItemWidth.swift; sourceTree = "<group>"; };
+		29792B231FFB3EF6007A0C57 /* HangingChadItemWidthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangingChadItemWidthTests.swift; sourceTree = "<group>"; };
 		297A372B1F1700BC0081C04E /* IssueRequestModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueRequestModel.swift; sourceTree = "<group>"; };
 		297A372D1F17018F0081C04E /* IssueRequestCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueRequestCell.swift; sourceTree = "<group>"; };
 		297A372F1F1704C10081C04E /* IssueRequestSectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueRequestSectionController.swift; sourceTree = "<group>"; };
@@ -1291,6 +1296,7 @@
 				2981A8A61EFEBEF900E25EF1 /* EmojiTests.swift */,
 				2986B35D1FD462AA00E3CFC6 /* FilePathTests.swift */,
 				296B4E331F7C80B800C16887 /* GraphQLIDDecodeTests.swift */,
+				29792B231FFB3EF6007A0C57 /* HangingChadItemWidthTests.swift */,
 				297AE84E1EC0D58A00B44A1F /* Info.plist */,
 				DC60C6D41F983DF800241271 /* IssueLabelCellTests.swift */,
 				29A476B11ED24D99005D0953 /* IssueTests.swift */,
@@ -1463,11 +1469,13 @@
 				291929541F3FAADF0012067B /* FeedRefresh.swift */,
 				299E86471EFD9DBB00E5FE70 /* FlexController.h */,
 				299E86481EFD9DBB00E5FE70 /* FlexController.m */,
+				29792B1E1FFB3E3A007A0C57 /* HangingChadItemWidth.swift */,
 				297B06291FB9239E0026FA23 /* IGListCollectionViewLayout+GitHawk.swift */,
 				299A049E1FAE1D0F003C2450 /* InitialEmptyView.swift */,
 				29AF1E871F8AB0AA0008A0EF /* IssueTextActionsView+Markdown.swift */,
 				98835BD11F1A158D005BA24F /* LabelCell.swift */,
 				D8BAD05F1FDA0A1A00C41071 /* LabelListCell.swift */,
+				D8BAD0631FDF221900C41071 /* LabelListView.swift */,
 				2963A9331EE2118E0066509C /* ResponderButton.swift */,
 				29C33FDE1F128D4400EC8D40 /* SelectableCell.swift */,
 				29EE44491F19D85800B05ED3 /* ShowErrorStatusBar.swift */,
@@ -1491,7 +1499,6 @@
 				29AF1E831F8AAB4A0008A0EF /* UITextView+GitHawk.swift */,
 				292FF8B11F302FE7009E63F7 /* UITextView+SelectedRange.swift */,
 				298BA08E1EC90FEE00B01946 /* UIView+BottomBorder.swift */,
-				D8BAD0631FDF221900C41071 /* LabelListView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2276,6 +2283,7 @@
 				29C0E7071ECBC6C50051D756 /* GithubClient.swift in Sources */,
 				2986B35A1FD30F0B00E3CFC6 /* IssueManagingModel.swift in Sources */,
 				2981A8A41EFE9FC700E25EF1 /* GithubEmoji.swift in Sources */,
+				29792B1F1FFB3E3A007A0C57 /* HangingChadItemWidth.swift in Sources */,
 				299F2A121EC3BCF0006CE9D7 /* GithubSessionManager.swift in Sources */,
 				29316DBD1ECC8970007CAE3F /* GithubUserSession.swift in Sources */,
 				986B873C1F2CEB1500AAB55C /* GQL+RepositoryIssueSummaryType.swift in Sources */,
@@ -2593,6 +2601,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				29792B241FFB3EF6007A0C57 /* HangingChadItemWidthTests.swift in Sources */,
 				293A45751F296B7E00DD1006 /* DateDisplayTests.swift in Sources */,
 				293A45761F296B7E00DD1006 /* IssueTests.swift in Sources */,
 				49D029001F91D90C00E39094 /* ReactionTests.swift in Sources */,
@@ -2601,6 +2610,7 @@
 				293A45771F296B7E00DD1006 /* ListKitTestCase.swift in Sources */,
 				DC5C02C51F9C6E3500E80B9F /* SearchQueryTests.swift in Sources */,
 				293A457E1F296BD500DD1006 /* API.swift in Sources */,
+				29792B221FFB3EE8007A0C57 /* HangingChadItemWidth.swift in Sources */,
 				2986B35F1FD462B300E3CFC6 /* FilePath.swift in Sources */,
 				293A45781F296B7E00DD1006 /* ListTestKit.swift in Sources */,
 				296B4E341F7C80B800C16887 /* GraphQLIDDecodeTests.swift in Sources */,

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		2974069F1F0EDED3003A6BFB /* IssueCommentTableCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2974069E1F0EDED3003A6BFB /* IssueCommentTableCollectionCell.swift */; };
 		297406A11F0EE51E003A6BFB /* MMElement+Table.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297406A01F0EE51E003A6BFB /* MMElement+Table.swift */; };
 		29764C141FDC4DB60095FF95 /* SettingsLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29764C131FDC4DB60095FF95 /* SettingsLabel.swift */; };
+		29792B1D1FFB2FC6007A0C57 /* IssueManagingNavSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29792B1C1FFB2FC6007A0C57 /* IssueManagingNavSectionController.swift */; };
 		297A372C1F1700BC0081C04E /* IssueRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297A372B1F1700BC0081C04E /* IssueRequestModel.swift */; };
 		297A372E1F17018F0081C04E /* IssueRequestCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297A372D1F17018F0081C04E /* IssueRequestCell.swift */; };
 		297A37301F1704C10081C04E /* IssueRequestSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297A372F1F1704C10081C04E /* IssueRequestSectionController.swift */; };
@@ -606,6 +607,7 @@
 		2974069E1F0EDED3003A6BFB /* IssueCommentTableCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCommentTableCollectionCell.swift; sourceTree = "<group>"; };
 		297406A01F0EE51E003A6BFB /* MMElement+Table.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MMElement+Table.swift"; sourceTree = "<group>"; };
 		29764C131FDC4DB60095FF95 /* SettingsLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsLabel.swift; sourceTree = "<group>"; };
+		29792B1C1FFB2FC6007A0C57 /* IssueManagingNavSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueManagingNavSectionController.swift; sourceTree = "<group>"; };
 		297A372B1F1700BC0081C04E /* IssueRequestModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueRequestModel.swift; sourceTree = "<group>"; };
 		297A372D1F17018F0081C04E /* IssueRequestCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueRequestCell.swift; sourceTree = "<group>"; };
 		297A372F1F1704C10081C04E /* IssueRequestSectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueRequestSectionController.swift; sourceTree = "<group>"; };
@@ -1537,6 +1539,7 @@
 				2993046A1FBA8C04007B9737 /* IssueManagingExpansionCell.swift */,
 				2986B3571FD30EC400E3CFC6 /* IssueManagingExpansionModel.swift */,
 				2986B3591FD30F0B00E3CFC6 /* IssueManagingModel.swift */,
+				29792B1C1FFB2FC6007A0C57 /* IssueManagingNavSectionController.swift */,
 				299304681FBA8A88007B9737 /* IssueManagingSectionController.swift */,
 			);
 			path = Managing;
@@ -2476,6 +2479,7 @@
 				986B87341F2CAE9800AAB55C /* RepositoryIssueSummaryType.swift in Sources */,
 				2905AFAD1F7357C50015AE32 /* RepositoryIssuesViewController.swift in Sources */,
 				29EE1C1D1F3A33890046A54D /* RepositoryLabel.swift in Sources */,
+				29792B1D1FFB2FC6007A0C57 /* IssueManagingNavSectionController.swift in Sources */,
 				2905AFAB1F7357B40015AE32 /* RepositoryOverviewViewController.swift in Sources */,
 				29EDFE821F661562005BCCEB /* RepositoryReadmeModel.swift in Sources */,
 				29EDFE841F661776005BCCEB /* RepositoryReadmeSectionController.swift in Sources */,

--- a/FreetimeTests/HangingChadItemWidthTests.swift
+++ b/FreetimeTests/HangingChadItemWidthTests.swift
@@ -1,0 +1,69 @@
+//
+//  HangingChadItemWidthTests.swift
+//  FreetimeTests
+//
+//  Created by Ryan Nystrom on 1/1/18.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import XCTest
+
+class HangingChadItemWidthTests: XCTestCase {
+    
+    func test_whenCountEmpty() {
+        XCTAssertEqual(HangingChadItemWidth(index: 0, count: 0, containerWidth: 300, desiredItemWidth: 30), 0)
+    }
+
+    func test_whenIndexOOB() {
+        XCTAssertEqual(HangingChadItemWidth(index: 3, count: 2, containerWidth: 300, desiredItemWidth: 30), 0)
+    }
+
+    func test_whenCountOne_withDesiredWidthLessThanContainer() {
+        XCTAssertEqual(HangingChadItemWidth(index: 0, count: 1, containerWidth: 300, desiredItemWidth: 30), 300)
+    }
+
+    func test_whenIndexLessThanCount_withDesiredWidthLessThanContainer() {
+        XCTAssertEqual(HangingChadItemWidth(index: 0, count: 2, containerWidth: 300, desiredItemWidth: 30), 150)
+    }
+
+    func test_whenIndexZero_withSingleRow() {
+        XCTAssertEqual(HangingChadItemWidth(index: 0, count: 10, containerWidth: 300, desiredItemWidth: 30), 30)
+    }
+
+    func test_whenIndexLessThanCount_withSingleRow() {
+        XCTAssertEqual(HangingChadItemWidth(index: 5, count: 10, containerWidth: 300, desiredItemWidth: 30), 30)
+    }
+
+    func test_whenIndexZero_withTwoRows() {
+        XCTAssertEqual(HangingChadItemWidth(index: 0, count: 20, containerWidth: 300, desiredItemWidth: 30), 30)
+    }
+
+    func test_whenIndexFirstRow_withTwoRows() {
+        XCTAssertEqual(HangingChadItemWidth(index: 5, count: 20, containerWidth: 300, desiredItemWidth: 30), 30)
+    }
+
+    func test_whenIndexSecondRow_withTwoRows() {
+        XCTAssertEqual(HangingChadItemWidth(index: 15, count: 20, containerWidth: 300, desiredItemWidth: 30), 30)
+    }
+
+    func test_whenTwoRows_withSingleItems_withIndexZero() {
+        XCTAssertEqual(HangingChadItemWidth(index: 0, count: 2, containerWidth: 300, desiredItemWidth: 300), 300)
+    }
+
+    func test_whenTwoRows_withSingleItems_withIndexOne() {
+        XCTAssertEqual(HangingChadItemWidth(index: 1, count: 2, containerWidth: 300, desiredItemWidth: 300), 300)
+    }
+
+    func test_whenTwoRows_withHangingChad_withIndexZero() {
+        XCTAssertEqual(HangingChadItemWidth(index: 0, count: 21, containerWidth: 300, desiredItemWidth: 30), 30)
+    }
+
+    func test_whenTwoRows_withHangingChad_withSecondLastIndex() {
+        XCTAssertEqual(HangingChadItemWidth(index: 19, count: 21, containerWidth: 300, desiredItemWidth: 30), 150)
+    }
+
+    func test_whenTwoRows_withHangingChad_withLastIndex() {
+        XCTAssertEqual(HangingChadItemWidth(index: 20, count: 21, containerWidth: 300, desiredItemWidth: 30), 150)
+    }
+    
+}

--- a/FreetimeTests/HangingChadItemWidthTests.swift
+++ b/FreetimeTests/HangingChadItemWidthTests.swift
@@ -58,6 +58,14 @@ class HangingChadItemWidthTests: XCTestCase {
         XCTAssertEqual(HangingChadItemWidth(index: 0, count: 21, containerWidth: 300, desiredItemWidth: 30), 30)
     }
 
+    func test_whenTwoRows_withHangingChad_withIndexOnFirstRow() {
+        XCTAssertEqual(HangingChadItemWidth(index: 5, count: 21, containerWidth: 300, desiredItemWidth: 30), 30)
+    }
+
+    func test_whenTwoRows_withHangingChad_withIndexOnAdjustedSecondRow() {
+        XCTAssertEqual(HangingChadItemWidth(index: 15, count: 21, containerWidth: 300, desiredItemWidth: 30), 33)
+    }
+
     func test_whenTwoRows_withHangingChad_withSecondLastIndex() {
         XCTAssertEqual(HangingChadItemWidth(index: 19, count: 21, containerWidth: 300, desiredItemWidth: 30), 150)
     }


### PR DESCRIPTION
Fixes #1325, #1322

- Tapping manage button now just scrolls to bottom
- Actions always displayed when you can admin
- Adjust layout math to evenly distribute options, no single action hanging

![simulator screen shot - iphone x - 2018-01-01 at 23 49 24](https://user-images.githubusercontent.com/739696/34474561-97140492-ef4e-11e7-96fd-9896c156a73d.png)
![simulator screen shot - iphone x - 2018-01-01 at 23 49 30](https://user-images.githubusercontent.com/739696/34474562-971df20e-ef4e-11e7-8e17-db8d10e25c5e.png)
![simulator screen shot - iphone x - 2018-01-01 at 23 49 31](https://user-images.githubusercontent.com/739696/34474563-9726eba2-ef4e-11e7-976e-923f705e92db.png)
