### PR TITLE
Remove assert firing on wrong bar item

### DIFF
--- a/Classes/Notifications/NotificationsViewController.swift
+++ b/Classes/Notifications/NotificationsViewController.swift
@@ -125,11 +125,7 @@ FlatCacheListener {
         }
 
         let hasUnread = count > 0
-        let markAllItem = navigationItem.rightBarButtonItem
-        if let markAllItem = markAllItem {
-            assert(markAllItem.action == #selector(onMarkAll)) // https://github.com/rnystrom/GitHawk/issues/1293
-        }
-        markAllItem?.isEnabled = hasUnread
+        navigationItem.rightBarButtonItem?.isEnabled = hasUnread
         navigationController?.tabBarItem.badgeValue = hasUnread ? "\(count)" : nil
         BadgeNotifications.update(count: count)
     }


### PR DESCRIPTION
This is asserting when the right bar item is a spinner. Removing. cc @BasThomas 