### PR TITLE
Use lru cache for current bitmap caching

### DIFF
--- a/Local Pods/StyledText/StyledText/CGImage+LRUCachable.swift
+++ b/Local Pods/StyledText/StyledText/CGImage+LRUCachable.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension CGImage: LRUCachable {
 
-    var cachedSize: Int {
+    public var cachedSize: Int {
         return height * bytesPerRow
     }
 

--- a/Local Pods/StyledText/StyledText/CGSize+LRUCachable.swift
+++ b/Local Pods/StyledText/StyledText/CGSize+LRUCachable.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension CGSize: LRUCachable {
 
-    var cachedSize: Int {
+    public var cachedSize: Int {
         return 1
     }
 

--- a/Local Pods/StyledText/StyledText/Hashable+Combined.swift
+++ b/Local Pods/StyledText/StyledText/Hashable+Combined.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension Hashable {
 
-    internal func combineHash<T: Hashable>(with hashableOther: T) -> Int {
+    public func combineHash<T: Hashable>(with hashableOther: T) -> Int {
         let ownHash = self.hashValue
         let otherHash = hashableOther.hashValue
         return (ownHash << 5) &+ ownHash &+ otherHash

--- a/Local Pods/StyledText/StyledText/LRUCache.swift
+++ b/Local Pods/StyledText/StyledText/LRUCache.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-internal protocol LRUCachable {
+public protocol LRUCachable {
     var cachedSize: Int { get }
 }
 
-internal final class LRUCache<Key: Hashable & Equatable, Value: LRUCachable> {
+public final class LRUCache<Key: Hashable & Equatable, Value: LRUCachable> {
 
     internal class Node {
 
@@ -54,7 +54,7 @@ internal final class LRUCache<Key: Hashable & Equatable, Value: LRUCachable> {
     public let maxSize: Int
     public let compaction: Compaction
 
-    init(maxSize: Int, compaction: Compaction = .default, clearOnWarning: Bool = false) {
+    public init(maxSize: Int, compaction: Compaction = .default, clearOnWarning: Bool = false) {
         self.maxSize = maxSize
 
         switch compaction {


### PR DESCRIPTION
Excited to see this in action. You can now open tons of issues and memory doesn't continue to grow.

Atm the `FlatCache` uses a singleton that stores models holding refs to `NSAttributedStringSizing`. These string objects only purge memory on warning which could be too late. Now we cap at 20mb (the default that the `StyledText` lib uses, migration is tbd tho).