### PR TITLE
Card inset design completely overhauled

### DIFF
--- a/Classes/Issues/Assignees/IssueAssigneeSummaryCell.swift
+++ b/Classes/Issues/Assignees/IssueAssigneeSummaryCell.swift
@@ -35,7 +35,7 @@ final class IssueAssigneeSummaryCell: UICollectionViewCell, UICollectionViewData
         contentView.addSubview(label)
         label.snp.makeConstraints { make in
             make.centerY.equalTo(contentView)
-            make.left.equalTo(Styles.Sizes.gutter)
+            make.left.equalTo(contentView)
         }
 
         collectionView.backgroundColor = .clear

--- a/Classes/Issues/Assignees/IssueAssigneeUserCell.swift
+++ b/Classes/Issues/Assignees/IssueAssigneeUserCell.swift
@@ -30,7 +30,7 @@ final class IssueAssigneeUserCell: UICollectionViewCell, ListBindable {
         contentView.addSubview(imageView)
         imageView.snp.makeConstraints { make in
             make.centerY.equalTo(contentView)
-            make.left.equalTo(Styles.Sizes.gutter)
+            make.left.equalTo(contentView)
             make.size.equalTo(Styles.Sizes.icon)
         }
 

--- a/Classes/Issues/Assignees/IssueAssigneesSectionController.swift
+++ b/Classes/Issues/Assignees/IssueAssigneesSectionController.swift
@@ -19,8 +19,9 @@ ListBindingSectionControllerSelectionDelegate {
         super.init()
         dataSource = self
         selectionDelegate = self
-        minimumLineSpacing = Styles.Sizes.rowSpacing/2
-        inset = UIEdgeInsets(top: 0, left: 0, bottom: Styles.Sizes.rowSpacing, right: 0)
+        let spacing = Styles.Sizes.rowSpacing / 2
+        minimumLineSpacing = spacing
+        inset = UIEdgeInsets(top: spacing, left: 0, bottom: spacing, right: 0)
     }
 
     // MARK: ListBindingSectionControllerDataSource
@@ -59,7 +60,7 @@ ListBindingSectionControllerSelectionDelegate {
         sizeForViewModel viewModel: Any,
         at index: Int
         ) -> CGSize {
-        guard let width = collectionContext?.containerSize.width
+        guard let width = collectionContext?.insetContainerSize.width
             else { fatalError("Collection context must be set") }
         return CGSize(
             width: width,

--- a/Classes/Issues/Comments/IssueCommentBaseCell.swift
+++ b/Classes/Issues/Comments/IssueCommentBaseCell.swift
@@ -62,7 +62,7 @@ class IssueCommentBaseCell: UICollectionViewCell, UIGestureRecognizerDelegate {
 
         let bounds = contentView.frame
         let inset = borderLayer.lineWidth / 2
-        let pixelSnapBounds = self.bounds.insetBy(dx: inset, dy: inset)
+        let pixelSnapBounds = bounds.insetBy(dx: inset, dy: inset)
         let cornerRadius = Styles.Sizes.cardCornerRadius
 
         let borderPath = UIBezierPath()

--- a/Classes/Issues/Comments/IssueCommentModel+Inset.swift
+++ b/Classes/Issues/Comments/IssueCommentModel+Inset.swift
@@ -11,41 +11,20 @@ import UIKit
 extension IssueCommentModel {
 
     var commentSectionControllerInset: UIEdgeInsets {
-        let gutter = Styles.Sizes.commentGutter
         let rowSpacing = Styles.Sizes.rowSpacing
 
         switch threadState {
         case .single:
             // title and other header objects will have bottom insetting
             if isRoot {
-                return UIEdgeInsets(
-                    top: 0,
-                    left: gutter,
-                    bottom: rowSpacing,
-                    right: gutter
-                )
+                return UIEdgeInsets(top: 12, left: 0, bottom: rowSpacing, right: 0)
             } else {
-                return UIEdgeInsets(
-                    top: rowSpacing,
-                    left: gutter,
-                    bottom: rowSpacing,
-                    right: gutter
-                )
+                return UIEdgeInsets(top: rowSpacing, left: 0, bottom: rowSpacing, right: 0)
             }
         case .neck:
-            return UIEdgeInsets(
-                top: 0,
-                left: gutter,
-                bottom: 0,
-                right: gutter
-            )
+            return .zero
         case .tail:
-            return UIEdgeInsets(
-                top: 0,
-                left: gutter,
-                bottom: rowSpacing,
-                right: gutter
-            )
+            return UIEdgeInsets(top: 0, left: 0, bottom: rowSpacing, right: 0)
         }
     }
 

--- a/Classes/Issues/Comments/IssueCommentSectionController.swift
+++ b/Classes/Issues/Comments/IssueCommentSectionController.swift
@@ -163,7 +163,7 @@ IssueCommentDoubleTapDelegate {
     }
 
     func edit(markdown: String) {
-        guard let width = collectionContext?.containerSize.width else { return }
+        guard let width = collectionContext?.insetContainerSize.width else { return }
         let options = commentModelOptions(owner: model.owner, repo: model.repo)
         let bodyModels = CreateCommentModels(markdown: markdown, width: width, options: options, viewerCanUpdate: true)
         bodyEdits = (markdown, bodyModels)
@@ -230,7 +230,7 @@ IssueCommentDoubleTapDelegate {
         guard let viewModel = viewModel as? ListDiffable
             else { fatalError("Collection context must be set") }
 
-        let width = (collectionContext?.containerSize.width ?? 0) - inset.left - inset.right
+        let width = (collectionContext?.insetContainerSize.width ?? 0) - inset.left - inset.right
 
         let height: CGFloat
         if collapsed && (viewModel as AnyObject) === object?.collapse?.model {

--- a/Classes/Issues/Comments/Tables/IssueCommentTableCell.swift
+++ b/Classes/Issues/Comments/Tables/IssueCommentTableCell.swift
@@ -14,7 +14,12 @@ final class IssueCommentTableCell: IssueCommentBaseCell,
     UICollectionViewDataSource,
 UICollectionViewDelegateFlowLayout {
 
-    static let inset = UIEdgeInsets(top: 0, left: 4, bottom: Styles.Sizes.rowSpacing, right: 4)
+    static let inset = UIEdgeInsets(
+        top: 0,
+        left: Styles.Sizes.rowSpacing / 2,
+        bottom: Styles.Sizes.rowSpacing,
+        right: Styles.Sizes.rowSpacing / 2
+    )
 
     weak var delegate: AttributedStringViewDelegate?
 

--- a/Classes/Issues/Commit/IssueCommitSectionController.swift
+++ b/Classes/Issues/Commit/IssueCommitSectionController.swift
@@ -19,7 +19,7 @@ final class IssueCommitSectionController: ListGenericSectionController<IssueComm
     }
 
     override func sizeForItem(at index: Int) -> CGSize {
-        guard let width = collectionContext?.containerSize.width else { fatalError("Collection context must be set") }
+        guard let width = collectionContext?.insetContainerSize.width else { fatalError("Collection context must be set") }
         return CGSize(width: width, height: Styles.Sizes.labelEventHeight)
     }
 

--- a/Classes/Issues/DiffHunk/IssueDiffHunkPreviewCell.swift
+++ b/Classes/Issues/DiffHunk/IssueDiffHunkPreviewCell.swift
@@ -13,9 +13,9 @@ final class IssueDiffHunkPreviewCell: IssueCommentBaseCell, ListBindable {
 
     static let textViewInset = UIEdgeInsets(
         top: Styles.Sizes.rowSpacing,
-        left: Styles.Sizes.gutter,
+        left: Styles.Sizes.commentGutter,
         bottom: Styles.Sizes.rowSpacing,
-        right: Styles.Sizes.gutter
+        right: Styles.Sizes.commentGutter
     )
 
     let scrollView = UIScrollView()

--- a/Classes/Issues/DiffHunk/IssueDiffHunkSectionController.swift
+++ b/Classes/Issues/DiffHunk/IssueDiffHunkSectionController.swift
@@ -13,8 +13,7 @@ final class IssueDiffHunkSectionController: ListBindingSectionController<IssueDi
 
     override init() {
         super.init()
-        let gutter = Styles.Sizes.commentGutter
-        self.inset = UIEdgeInsets(top: Styles.Sizes.rowSpacing, left: gutter, bottom: 0, right: gutter)
+        self.inset = UIEdgeInsets(top: Styles.Sizes.rowSpacing, left: 0, bottom: 0, right: 0)
         dataSource = self
     }
 
@@ -36,7 +35,7 @@ final class IssueDiffHunkSectionController: ListBindingSectionController<IssueDi
         sizeForViewModel viewModel: Any,
         at index: Int
         ) -> CGSize {
-        let width = (collectionContext?.containerSize.width ?? 0) - inset.left - inset.right
+        let width = (collectionContext?.insetContainerSize.width ?? 0) - inset.left - inset.right
         let height: CGFloat
         if let viewModel = viewModel as? NSAttributedStringSizing {
             height = viewModel.textViewSize(0).height

--- a/Classes/Issues/Files/IssueFilesViewController.swift
+++ b/Classes/Issues/Files/IssueFilesViewController.swift
@@ -78,7 +78,7 @@ ListSingleSectionControllerDelegate {
             cell.configure(path: file.filename, additions: file.additions.intValue, deletions: file.deletions.intValue)
         }
         let size: (Any, ListCollectionContext?) -> CGSize = { (file, context) in
-            guard let width = context?.containerSize.width else { fatalError("Missing context") }
+            guard let width = context?.insetContainerSize.width else { fatalError("Missing context") }
             return CGSize(width: width, height: Styles.Sizes.tableCellHeightLarge)
         }
         let controller = ListSingleSectionController(
@@ -100,8 +100,8 @@ ListSingleSectionControllerDelegate {
                 let strongSelf = self
                 else { return .zero }
             return CGSize(
-                width: context.containerSize.width,
-                height: context.containerSize.height - strongSelf.topLayoutGuide.length - strongSelf.bottomLayoutGuide.length
+                width: context.insetContainerSize.width,
+                height: context.insetContainerSize.height - strongSelf.topLayoutGuide.length - strongSelf.bottomLayoutGuide.length
             )
         }
         let controller = ListSingleSectionController(

--- a/Classes/Issues/Files/IssueViewFilesCell.swift
+++ b/Classes/Issues/Files/IssueViewFilesCell.swift
@@ -20,7 +20,7 @@ final class IssueViewFilesCell: UICollectionViewCell {
 
         contentView.addSubview(label)
         label.snp.makeConstraints { make in
-            make.left.equalTo(Styles.Sizes.gutter)
+            make.left.equalTo(contentView)
             make.centerY.equalTo(contentView)
         }
     }

--- a/Classes/Issues/Files/IssueViewFilesSectionController.swift
+++ b/Classes/Issues/Files/IssueViewFilesSectionController.swift
@@ -18,11 +18,12 @@ final class IssueViewFilesSectionController: ListGenericSectionController<IssueF
         self.issueModel = issueModel
         self.client = client
         super.init()
-        inset = UIEdgeInsets(top: 0, left: 0, bottom: Styles.Sizes.rowSpacing, right: 0)
+        let spacing = Styles.Sizes.rowSpacing / 2
+        inset = UIEdgeInsets(top: spacing, left: 0, bottom: spacing, right: 0)
     }
 
     override func sizeForItem(at index: Int) -> CGSize {
-        guard let width = collectionContext?.containerSize.width else { fatalError("Collection context must be set") }
+        guard let width = collectionContext?.insetContainerSize.width else { fatalError("Collection context must be set") }
         return CGSize(
             width: width,
             height: Styles.Fonts.secondary.lineHeight

--- a/Classes/Issues/IssueViewModels.swift
+++ b/Classes/Issues/IssueViewModels.swift
@@ -13,8 +13,8 @@ func titleStringSizing(title: String, width: CGFloat) -> NSAttributedStringSizin
     let attributedString = NSAttributedString(
         string: title,
         attributes: [
-            NSAttributedStringKey.font: Styles.Fonts.headline,
-            NSAttributedStringKey.foregroundColor: Styles.Colors.Gray.dark.color
+            .font: Styles.Fonts.headline,
+            .foregroundColor: Styles.Colors.Gray.dark.color
         ])
     return NSAttributedStringSizing(
         containerWidth: width,

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -28,7 +28,6 @@ IssueManagingNavSectionControllerDelegate {
     private let addCommentClient: AddCommentClient
     private let textActionsController = TextActionsController()
     private var bookmarkNavController: BookmarkNavigationController? = nil
-    private let collectionView = UICollectionView(frame: .zero, collectionViewLayout: ListCollectionViewLayout.basic())
     private var autocompleteController: AutocompleteController!
 
     private var needsScrollToBottom = false
@@ -37,12 +36,11 @@ IssueManagingNavSectionControllerDelegate {
     private var viewerIsCollaborator = false
     private let manageKey = "manageKey" as ListDiffable
 
-    lazy private var feed: Feed = { Feed(
-        viewController: self,
-        delegate: self,
-        collectionView: self.collectionView,
-        managesLayout: false
-        ) }()
+    lazy private var feed: Feed = {
+        let f = Feed(viewController: self, delegate: self, managesLayout: false)
+        f.collectionView.contentInset = Styles.Sizes.threadInset
+        return f
+    }()
 
     private var resultID: String? = nil {
         didSet {
@@ -119,7 +117,7 @@ IssueManagingNavSectionControllerDelegate {
         feed.adapter.dataSource = self
 
         // setup after feed is lazy loaded
-        setup(scrollView: collectionView)
+        setup(scrollView: feed.collectionView)
         setMessageView(hidden: true, animated: false)
 
         // override Feed bg color setting
@@ -133,7 +131,12 @@ IssueManagingNavSectionControllerDelegate {
         messageView.set(buttonIcon: UIImage(named: "send")?.withRenderingMode(.alwaysTemplate), for: .normal)
         messageView.buttonTint = Styles.Colors.Blue.medium.color
         messageView.font = Styles.Fonts.body
-        messageView.inset = UIEdgeInsets(top: Styles.Sizes.gutter, left: Styles.Sizes.gutter, bottom: 4, right: Styles.Sizes.gutter)
+        messageView.inset = UIEdgeInsets(
+            top: Styles.Sizes.gutter,
+            left: Styles.Sizes.gutter,
+            bottom: Styles.Sizes.rowSpacing / 2,
+            right: Styles.Sizes.gutter
+        )
         messageView.addButton(target: self, action: #selector(didPressButton(_:)))
 
         let getMarkdownBlock = { [weak self] () -> (String) in
@@ -275,11 +278,16 @@ IssueManagingNavSectionControllerDelegate {
             }
         }
 
+        // assumptions here, but the collectionview may not have been laid out or content size found
+        // assume the collectionview is pinned to the view's bounds
+        let contentInset = feed.collectionView.contentInset
+        let width = view.bounds.width - contentInset.left - contentInset.right
+
         client.fetch(
             owner: model.owner,
             repo: model.repo,
             number: model.number,
-            width: view.bounds.width,
+            width: width,
             prependResult: previous ? result : nil
         ) { [weak self] resultType in
             guard let strongSelf = self else { return }
@@ -335,7 +343,10 @@ IssueManagingNavSectionControllerDelegate {
         guard paddedMaxY > viewportHeight else { return }
 
         let offset = paddedMaxY - viewportHeight
-        collectionView.setContentOffset(CGPoint(x: 0, y: offset), animated: trueUnlessReduceMotionEnabled)
+        collectionView.setContentOffset(
+            CGPoint(x: collectionView.contentOffset.x, y: offset),
+            animated: trueUnlessReduceMotionEnabled
+        )
     }
 
     func onPreview() {
@@ -358,22 +369,27 @@ IssueManagingNavSectionControllerDelegate {
             objects.append(manageKey)
         }
 
-        objects.append(current.title)
-        objects.append(current.labels)
-
+        // BEGIN collect metadata that lives between title and root comment
+        var metadata = [ListDiffable]()
+        if current.labels.labels.count > 0 {
+            metadata.append(current.labels)
+        }
         if let milestone = current.milestone {
-            objects.append(milestone)
+            metadata.append(milestone)
         }
-
-        objects.append(current.assignee)
-
+        if current.assignee.users.count > 0 {
+            metadata.append(current.assignee)
+        }
         if let reviewers = current.reviewers {
-            objects.append(reviewers)
+            metadata.append(reviewers)
         }
-
         if let changes = current.fileChanges {
-            objects.append(IssueFileChangesModel(changes: changes))
+            metadata.append(IssueFileChangesModel(changes: changes))
         }
+        // END metadata collection
+
+        objects.append(IssueTitleModel(attributedString: current.title, trailingMetadata: metadata.count > 0))
+        objects += metadata
 
         if let rootComment = current.rootComment {
             objects.append(rootComment)
@@ -402,7 +418,7 @@ IssueManagingNavSectionControllerDelegate {
         }
 
         switch object {
-        case is NSAttributedStringSizing: return IssueTitleSectionController()
+        case is IssueTitleModel: return IssueTitleSectionController()
         case is IssueCommentModel: return IssueCommentSectionController(
             model: model,
             client: client,
@@ -517,7 +533,7 @@ IssueManagingNavSectionControllerDelegate {
     // MARK: IssueManagingNavSectionControllerDelegate
 
     func didSelect(managingNavController: IssueManagingNavSectionController) {
-        collectionView.scrollToBottom(animated: true)
+        feed.collectionView.scrollToBottom(animated: true)
     }
 
 }

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -183,6 +183,13 @@ IssueManagingNavSectionControllerDelegate {
         feed.viewWillLayoutSubviews(view: view)
     }
 
+    override func viewSafeAreaInsetsDidChange() {
+        if #available(iOS 11.0, *) {
+            super.viewSafeAreaInsetsDidChange()
+            feed.collectionView.updateSafeInset(container: view, base: Styles.Sizes.threadInset)
+        }
+    }
+
     // MARK: Private API
 
     @objc func didPressButton(_ sender: Any?) {

--- a/Classes/Issues/Labeled/IssueLabeledSectionController.swift
+++ b/Classes/Issues/Labeled/IssueLabeledSectionController.swift
@@ -19,7 +19,7 @@ final class IssueLabeledSectionController: ListGenericSectionController<IssueLab
     }
 
     override func sizeForItem(at index: Int) -> CGSize {
-        guard let width = collectionContext?.containerSize.width else { fatalError("Collection context must be set") }
+        guard let width = collectionContext?.insetContainerSize.width else { fatalError("Collection context must be set") }
         return CGSize(width: width, height: object?.attributedString.textViewSize(width).height ?? 0)
     }
 

--- a/Classes/Issues/Labels/IssueLabelsSectionController.swift
+++ b/Classes/Issues/Labels/IssueLabelsSectionController.swift
@@ -21,12 +21,8 @@ ListBindingSectionControllerSelectionDelegate {
         super.init()
         minimumInteritemSpacing = Styles.Sizes.labelSpacing
         minimumLineSpacing = Styles.Sizes.labelSpacing
-        inset = UIEdgeInsets(
-            top: 0,
-            left: Styles.Sizes.gutter,
-            bottom: Styles.Sizes.rowSpacing,
-            right: Styles.Sizes.gutter
-        )
+        let spacing = Styles.Sizes.rowSpacing / 2
+        inset = UIEdgeInsets(top: spacing, left: 0, bottom: spacing, right: 0)
         dataSource = self
         selectionDelegate = self
     }

--- a/Classes/Issues/Managing/IssueManagingExpansionCell.swift
+++ b/Classes/Issues/Managing/IssueManagingExpansionCell.swift
@@ -38,7 +38,7 @@ final class IssueManagingExpansionCell: UICollectionViewCell, ListBindable {
         contentView.addSubview(chevron)
         chevron.snp.makeConstraints { make in
             make.centerY.equalTo(contentView).offset(1)
-            make.right.equalTo(contentView).offset(-Styles.Sizes.gutter)
+            make.right.equalTo(contentView)
         }
 
         label.text = NSLocalizedString("Manage", comment: "")

--- a/Classes/Issues/Managing/IssueManagingNavSectionController.swift
+++ b/Classes/Issues/Managing/IssueManagingNavSectionController.swift
@@ -22,7 +22,7 @@ final class IssueManagingNavSectionController: ListSectionController {
     }
 
     override func sizeForItem(at index: Int) -> CGSize {
-        guard let containerWidth = collectionContext?.containerSize.width
+        guard let containerWidth = collectionContext?.insetContainerSize.width
             else { fatalError("Collection context must be set") }
         return CGSize(
             width: floor(containerWidth / 2),

--- a/Classes/Issues/Managing/IssueManagingSectionController.swift
+++ b/Classes/Issues/Managing/IssueManagingSectionController.swift
@@ -201,7 +201,7 @@ PeopleViewControllerDelegate {
         sizeForViewModel viewModel: Any,
         at index: Int
         ) -> CGSize {
-        guard let containerWidth = collectionContext?.containerSize.width
+        guard let containerWidth = collectionContext?.insetContainerSize.width
             else { fatalError("Collection context must be set") }
 
         let height = IssueManagingActionCell.height

--- a/Classes/Issues/Milestone/IssueMilestoneCell.swift
+++ b/Classes/Issues/Milestone/IssueMilestoneCell.swift
@@ -23,7 +23,7 @@ final class IssueMilestoneCell: UICollectionViewCell {
         contentView.addSubview(titleLabel)
         titleLabel.snp.makeConstraints { make in
             make.centerY.equalTo(contentView)
-            make.left.equalTo(Styles.Sizes.gutter)
+            make.left.equalTo(contentView)
         }
 
         progress.progressTintColor = Styles.Colors.Green.medium.color
@@ -34,7 +34,7 @@ final class IssueMilestoneCell: UICollectionViewCell {
             make.height.equalTo(6)
             // fit to gutter on all iphones, cap in landscape or ipad
             make.width.lessThanOrEqualTo(300).priority(.required)
-            make.right.equalTo(-Styles.Sizes.gutter)
+            make.right.equalTo(contentView)
             make.left.equalTo(titleLabel.snp.right).offset(Styles.Sizes.rowSpacing)
         }
     }

--- a/Classes/Issues/Milestone/IssueMilestoneSectionController.swift
+++ b/Classes/Issues/Milestone/IssueMilestoneSectionController.swift
@@ -19,7 +19,7 @@ final class IssueMilestoneSectionController: ListGenericSectionController<Milest
     }
 
     override func sizeForItem(at index: Int) -> CGSize {
-        guard let width = collectionContext?.containerSize.width else { fatalError("Missing context") }
+        guard let width = collectionContext?.insetContainerSize.width else { fatalError("Missing context") }
         return CGSize(
             width: width,
             height: Styles.Fonts.secondary.lineHeight + Styles.Sizes.rowSpacing

--- a/Classes/Issues/MilestoneEvent/IssueMilestoneEventSectionController.swift
+++ b/Classes/Issues/MilestoneEvent/IssueMilestoneEventSectionController.swift
@@ -12,7 +12,7 @@ import IGListKit
 final class IssueMilestoneEventSectionController: ListGenericSectionController<IssueMilestoneEventModel> {
 
     override func sizeForItem(at index: Int) -> CGSize {
-        guard let width = collectionContext?.containerSize.width,
+        guard let width = collectionContext?.insetContainerSize.width,
             let object = self.object
             else { fatalError("Collection context must be set") }
         return CGSize(

--- a/Classes/Issues/NeckLoad/IssueNeckLoadSectionController.swift
+++ b/Classes/Issues/NeckLoad/IssueNeckLoadSectionController.swift
@@ -23,7 +23,7 @@ final class IssueNeckLoadSectionController: ListSectionController {
     }
 
     override func sizeForItem(at index: Int) -> CGSize {
-        guard let width = collectionContext?.containerSize.width else { fatalError("Collection context must be set") }
+        guard let width = collectionContext?.insetContainerSize.width else { fatalError("Collection context must be set") }
         return CGSize(width: width, height: Styles.Sizes.tableCellHeight)
     }
 

--- a/Classes/Issues/Preview/IssuePreviewSectionController.swift
+++ b/Classes/Issues/Preview/IssuePreviewSectionController.swift
@@ -38,7 +38,7 @@ ListBindingSectionControllerDataSource {
         sizeForViewModel viewModel: Any,
         at index: Int
         ) -> CGSize {
-        guard let width = collectionContext?.containerSize.width else { fatalError("Missing context") }
+        guard let width = collectionContext?.insetContainerSize.width else { fatalError("Missing context") }
         let height = BodyHeightForComment(
             viewModel: viewModel,
             width: width,

--- a/Classes/Issues/Referenced/IssueReferencedSectionController.swift
+++ b/Classes/Issues/Referenced/IssueReferencedSectionController.swift
@@ -19,7 +19,7 @@ final class IssueReferencedSectionController: ListGenericSectionController<Issue
     }
 
     override func sizeForItem(at index: Int) -> CGSize {
-        guard let width = collectionContext?.containerSize.width,
+        guard let width = collectionContext?.insetContainerSize.width,
             let object = self.object
             else { fatalError("Missing context") }
         return CGSize(

--- a/Classes/Issues/ReferencedCommit/IssueReferencedCommitSectionController.swift
+++ b/Classes/Issues/ReferencedCommit/IssueReferencedCommitSectionController.swift
@@ -12,7 +12,7 @@ import IGListKit
 final class IssueReferencedCommitSectionController: ListGenericSectionController<IssueReferencedCommitModel> {
 
     override func sizeForItem(at index: Int) -> CGSize {
-        guard let width = collectionContext?.containerSize.width,
+        guard let width = collectionContext?.insetContainerSize.width,
             let object = self.object
             else { fatalError("Missing context") }
         return CGSize(

--- a/Classes/Issues/Renamed/IssueRenamedSectionController.swift
+++ b/Classes/Issues/Renamed/IssueRenamedSectionController.swift
@@ -12,7 +12,7 @@ import IGListKit
 final class IssueRenamedSectionController: ListGenericSectionController<IssueRenamedModel>, IssueRenamedCellDelegate {
 
     override func sizeForItem(at index: Int) -> CGSize {
-        guard let width = collectionContext?.containerSize.width,
+        guard let width = collectionContext?.insetContainerSize.width,
             let object = self.object
             else { fatalError("Missing context") }
         return CGSize(width: width, height: object.titleChangeString.textViewSize(width).height)

--- a/Classes/Issues/Request/IssueRequestSectionController.swift
+++ b/Classes/Issues/Request/IssueRequestSectionController.swift
@@ -12,7 +12,7 @@ import IGListKit
 final class IssueRequestSectionController: ListGenericSectionController<IssueRequestModel> {
 
     override func sizeForItem(at index: Int) -> CGSize {
-        guard let width = collectionContext?.containerSize.width,
+        guard let width = collectionContext?.insetContainerSize.width,
         let object = self.object
         else { fatalError("Collection context must be set") }
         return CGSize(

--- a/Classes/Issues/Review/IssueReviewSectionController.swift
+++ b/Classes/Issues/Review/IssueReviewSectionController.swift
@@ -36,9 +36,8 @@ IssueReviewViewCommentsCellDelegate {
         self.client = client
         self.autocomplete = autocomplete
         super.init()
-        let gutter = Styles.Sizes.commentGutter
         let rowSpacing = Styles.Sizes.rowSpacing
-        self.inset = UIEdgeInsets(top: rowSpacing, left: gutter, bottom: rowSpacing, right: gutter)
+        self.inset = UIEdgeInsets(top: rowSpacing, left: 0, bottom: rowSpacing, right: 0)
         self.dataSource = self
     }
 
@@ -61,7 +60,7 @@ IssueReviewViewCommentsCellDelegate {
         ) -> CGSize {
         guard let viewModel = viewModel as? ListDiffable
             else { fatalError("Missing context") }
-        let width = (collectionContext?.containerSize.width ?? 0) - inset.left - inset.right
+        let width = (collectionContext?.insetContainerSize.width ?? 0) - inset.left - inset.right
 
         // use default if IssueReviewDetailsModel
         let height: CGFloat

--- a/Classes/Issues/Review/IssueReviewViewCommentsCell.swift
+++ b/Classes/Issues/Review/IssueReviewViewCommentsCell.swift
@@ -29,7 +29,7 @@ final class IssueReviewViewCommentsCell: IssueCommentBaseCell, ListBindable {
         button.titleLabel?.font = Styles.Fonts.body
         contentView.addSubview(button)
         button.snp.makeConstraints { make in
-            make.left.equalTo(Styles.Sizes.gutter)
+            make.left.equalTo(Styles.Sizes.commentGutter)
             make.centerY.equalTo(contentView)
         }
 

--- a/Classes/Issues/Status/IssueStatusCell.swift
+++ b/Classes/Issues/Status/IssueStatusCell.swift
@@ -22,7 +22,7 @@ final class IssueStatusCell: UICollectionViewCell, ListBindable {
         contentView.addSubview(button)
         button.snp.makeConstraints { make in
             make.centerY.equalTo(contentView)
-            make.left.equalTo(Styles.Sizes.gutter)
+            make.left.equalTo(contentView)
         }
 
         lockedButton.setTitle(Constants.Strings.locked, for: .normal)

--- a/Classes/Issues/Status/IssueStatusSectionController.swift
+++ b/Classes/Issues/Status/IssueStatusSectionController.swift
@@ -11,13 +11,8 @@ import IGListKit
 
 final class IssueStatusSectionController: ListGenericSectionController<IssueStatusModel> {
 
-    override init() {
-        super.init()
-//        inset = UIEdgeInsets(top: 4, left: 0, bottom: 0, right: 0)
-    }
-
     override func sizeForItem(at index: Int) -> CGSize {
-        guard let width = collectionContext?.containerSize.width
+        guard let width = collectionContext?.insetContainerSize.width
             else { fatalError("Collection context must be set") }
         return CGSize(width: floor(width / 2), height: Styles.Sizes.labelEventHeight)
     }

--- a/Classes/Issues/StatusEvent/IssueStatusEventSectionController.swift
+++ b/Classes/Issues/StatusEvent/IssueStatusEventSectionController.swift
@@ -19,7 +19,7 @@ final class IssueStatusEventSectionController: ListGenericSectionController<Issu
     }
 
     override func sizeForItem(at index: Int) -> CGSize {
-        guard let width = collectionContext?.containerSize.width else { fatalError("Collection context must be set") }
+        guard let width = collectionContext?.insetContainerSize.width else { fatalError("Collection context must be set") }
         return CGSize(width: width, height: Styles.Sizes.labelEventHeight)
     }
 

--- a/Classes/Issues/Title/IssueTitleCell.swift
+++ b/Classes/Issues/Title/IssueTitleCell.swift
@@ -11,6 +11,6 @@ import SnapKit
 
 final class IssueTitleCell: AttributedStringCell {
 
-    static let inset = UIEdgeInsets(top: 0, left: Styles.Sizes.gutter, bottom: 0, right: Styles.Sizes.gutter)
+    static let inset = UIEdgeInsets.zero
 
 }

--- a/Classes/Issues/Title/IssueTitleModel.swift
+++ b/Classes/Issues/Title/IssueTitleModel.swift
@@ -1,0 +1,35 @@
+//
+//  IssueTitleModel.swift
+//  Freetime
+//
+//  Created by Ryan Nystrom on 1/13/18.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import Foundation
+import IGListKit
+
+final class IssueTitleModel: ListDiffable {
+
+    let attributedString: NSAttributedStringSizing
+    let trailingMetadata: Bool
+
+    init(attributedString: NSAttributedStringSizing, trailingMetadata: Bool) {
+        self.attributedString = attributedString
+        self.trailingMetadata = trailingMetadata
+    }
+
+    // MARK: ListDiffable
+
+    func diffIdentifier() -> NSObjectProtocol {
+        return attributedString.diffIdentifier()
+    }
+
+    func isEqual(toDiffableObject object: ListDiffable?) -> Bool {
+        if self === object { return true }
+        guard let object = object as? IssueTitleModel else { return false }
+        return trailingMetadata == object.trailingMetadata
+            && attributedString.isEqual(toDiffableObject: object)
+    }
+
+}

--- a/Classes/Issues/Title/IssueTitleSectionController.swift
+++ b/Classes/Issues/Title/IssueTitleSectionController.swift
@@ -9,24 +9,33 @@
 import UIKit
 import IGListKit
 
-final class IssueTitleSectionController: ListGenericSectionController<NSAttributedStringSizing> {
+final class IssueTitleSectionController: ListSectionController {
 
-    override init() {
-        super.init()
-        inset = UIEdgeInsets(top: 0, left: 0, bottom: Styles.Sizes.rowSpacing, right: 0)
+    var object: IssueTitleModel?
+
+    override func didUpdate(to object: Any) {
+        guard let object = object as? IssueTitleModel else { return }
+        self.object = object
+        let rowSpacing = Styles.Sizes.rowSpacing
+        inset = UIEdgeInsets(
+            top: rowSpacing,
+            left: 0,
+            bottom: rowSpacing / 2 + (object.trailingMetadata ? rowSpacing : 0),
+            right: 0
+        )
     }
 
     override func sizeForItem(at index: Int) -> CGSize {
-        guard let width = collectionContext?.containerSize.width
+        guard let width = collectionContext?.insetContainerSize.width
             else { fatalError("Collection context must be set") }
-        return CGSize(width: width, height: self.object?.textViewSize(width).height ?? 0)
+        return CGSize(width: width, height: self.object?.attributedString.textViewSize(width).height ?? 0)
     }
 
     override func cellForItem(at index: Int) -> UICollectionViewCell {
         guard let object = self.object,
             let cell = collectionContext?.dequeueReusableCell(of: IssueTitleCell.self, for: self, at: index) as? IssueTitleCell
             else { fatalError("Collection context must be set, missing object, or cell incorrect type") }
-        cell.set(attributedText: object)
+        cell.set(attributedText: object.attributedString)
         return cell
     }
 

--- a/Classes/PullRequestReviews/PullRequestReviewCommentsViewController.swift
+++ b/Classes/PullRequestReviews/PullRequestReviewCommentsViewController.swift
@@ -33,6 +33,13 @@ BaseListViewControllerDataSource {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func viewSafeAreaInsetsDidChange() {
+        if #available(iOS 11.0, *) {
+            super.viewSafeAreaInsetsDidChange()
+            feed.collectionView.updateSafeInset(container: view, base: Styles.Sizes.threadInset)
+        }
+    }
+
     // MARK: Overrides
 
     override func fetch(page: NSNumber?) {

--- a/Classes/PullRequestReviews/PullRequestReviewCommentsViewController.swift
+++ b/Classes/PullRequestReviews/PullRequestReviewCommentsViewController.swift
@@ -25,6 +25,7 @@ BaseListViewControllerDataSource {
             emptyErrorMessage: NSLocalizedString("Error loading review comments.", comment: ""),
             dataSource: self
         )
+        feed.collectionView.contentInset = Styles.Sizes.threadInset
         title = NSLocalizedString("Review Comments", comment: "")
     }
 

--- a/Classes/Views/FeedRefresh.swift
+++ b/Classes/Views/FeedRefresh.swift
@@ -10,7 +10,7 @@ import UIKit
 
 final class FeedRefresh {
 
-    let refreshControl = UIRefreshControl()
+    let refreshControl = FixedRefreshControl()
 
     private var refreshBegin: TimeInterval = -1
 
@@ -24,8 +24,11 @@ final class FeedRefresh {
     func beginRefreshing() {
         refreshControl.beginRefreshing()
         if let scrollView = refreshControl.superview as? UIScrollView {
+            let contentOffset = scrollView.contentOffset
             scrollView.setContentOffset(
-                CGPoint(x: 0, y: scrollView.contentOffset.y - refreshControl.bounds.height),
+                CGPoint(
+                    x: contentOffset.x,
+                    y: contentOffset.y - refreshControl.bounds.height),
                 animated: trueUnlessReduceMotionEnabled
             )
         }

--- a/Classes/Views/FixedRefreshControl.swift
+++ b/Classes/Views/FixedRefreshControl.swift
@@ -1,0 +1,25 @@
+//
+//  FixedRefreshControl.swift
+//  Freetime
+//
+//  Created by Ryan Nystrom on 1/13/18.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import UIKit
+
+// https://stackoverflow.com/q/48178076/940936
+final class FixedRefreshControl: UIRefreshControl {
+
+    override var frame: CGRect {
+        get { return super.frame }
+        set {
+            var newFrame = newValue
+            if let superScrollView = superview as? UIScrollView {
+                newFrame.origin.x = superScrollView.frame.minX - superScrollView.contentInset.left
+            }
+            super.frame = newFrame
+        }
+    }
+
+}

--- a/Classes/Views/LabelListCell.swift
+++ b/Classes/Views/LabelListCell.swift
@@ -50,11 +50,6 @@ final class LabelListCell: UICollectionViewCell, ListBindable {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        layoutContentViewForSafeAreaInsets()
-    }
-
     // MARK: ListBindable
 
     func bindViewModel(_ viewModel: Any) {

--- a/Classes/Views/Styles.swift
+++ b/Classes/Views/Styles.swift
@@ -12,7 +12,7 @@ enum Styles {
 
     enum Sizes {
         static let gutter: CGFloat = 15
-        static let eventGutter: CGFloat = 16 // comment gutter 2x
+        static let eventGutter: CGFloat = 8 // comment gutter 2x
         static let commentGutter: CGFloat = 8
         static let icon = CGSize(width: 20, height: 20)
         static let buttonMin = CGSize(width: 44, height: 44)
@@ -44,7 +44,13 @@ enum Styles {
         static let labelSpacing: CGFloat = 4
         static let labelTextPadding: CGFloat = 4
         static let cardCornerRadius: CGFloat = 6
-        
+        static let threadInset = UIEdgeInsets(
+            top: Styles.Sizes.rowSpacing / 2,
+            left: Styles.Sizes.commentGutter,
+            bottom: 0,
+            right: Styles.Sizes.commentGutter
+        )
+
         enum Text {
 
             private static func size(
@@ -77,7 +83,7 @@ enum Styles {
             static var secondary: CGFloat { return size(13) }
             static var title: CGFloat { return size(14) }
             static var button: CGFloat { return size(16) }
-            static var headline: CGFloat { return size(18) }
+            static var headline: CGFloat { return size(24) }
             static var smallTitle: CGFloat { return size(12) }
             static var h1: CGFloat { return size(24) }
             static var h2: CGFloat { return size(22) }

--- a/Classes/Views/UIScrollView+LeftRightSafeInset.swift
+++ b/Classes/Views/UIScrollView+LeftRightSafeInset.swift
@@ -1,0 +1,25 @@
+//
+//  UIScrollView+LeftRightSafeInset.swift
+//  Freetime
+//
+//  Created by Ryan Nystrom on 1/13/18.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import UIKit
+
+extension UIScrollView {
+
+    func updateSafeInset(container view: UIView, base inset: UIEdgeInsets) {
+        if #available(iOS 11.0, *) {
+            let safe = view.safeAreaInsets
+            contentInset = UIEdgeInsets(
+                top: inset.top,
+                left: inset.left + safe.left,
+                bottom: inset.bottom,
+                right: inset.right + safe.right
+            )
+        }
+    }
+
+}

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		290EF5791F06BAF4006A2160 /* NoNewNotificationsSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290EF5781F06BAF4006A2160 /* NoNewNotificationsSectionController.swift */; };
 		29136BDB200A626D007317BE /* FixedRefreshControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29136BDA200A626D007317BE /* FixedRefreshControl.swift */; };
 		29136BDD200A6C40007317BE /* IssueTitleModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29136BDC200A6C40007317BE /* IssueTitleModel.swift */; };
+		29136BDF200A7A75007317BE /* UIScrollView+LeftRightSafeInset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29136BDE200A7A75007317BE /* UIScrollView+LeftRightSafeInset.swift */; };
 		291929421F3EA8CD0012067B /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291929411F3EA8CD0012067B /* File.swift */; };
 		291929471F3EAB250012067B /* IssueDetailsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291929461F3EAB250012067B /* IssueDetailsModel.swift */; };
 		291929491F3EAD2E0012067B /* IssueViewFilesSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291929481F3EAD2E0012067B /* IssueViewFilesSectionController.swift */; };
@@ -449,6 +450,7 @@
 		290EF5781F06BAF4006A2160 /* NoNewNotificationsSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoNewNotificationsSectionController.swift; sourceTree = "<group>"; };
 		29136BDA200A626D007317BE /* FixedRefreshControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedRefreshControl.swift; sourceTree = "<group>"; };
 		29136BDC200A6C40007317BE /* IssueTitleModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueTitleModel.swift; sourceTree = "<group>"; };
+		29136BDE200A7A75007317BE /* UIScrollView+LeftRightSafeInset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+LeftRightSafeInset.swift"; sourceTree = "<group>"; };
 		291929411F3EA8CD0012067B /* File.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
 		291929461F3EAB250012067B /* IssueDetailsModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueDetailsModel.swift; sourceTree = "<group>"; };
 		291929481F3EAD2E0012067B /* IssueViewFilesSectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueViewFilesSectionController.swift; sourceTree = "<group>"; };
@@ -1478,6 +1480,7 @@
 				D8C2AEF41F9AA94600A95945 /* DotListView.swift */,
 				29C167681ECA016500439D62 /* EmptyView.swift */,
 				291929541F3FAADF0012067B /* FeedRefresh.swift */,
+				29136BDA200A626D007317BE /* FixedRefreshControl.swift */,
 				299E86471EFD9DBB00E5FE70 /* FlexController.h */,
 				299E86481EFD9DBB00E5FE70 /* FlexController.m */,
 				29792B1E1FFB3E3A007A0C57 /* HangingChadItemWidth.swift */,
@@ -1504,13 +1507,13 @@
 				29A195011EC66B8B00C3E289 /* UIColor+Hex.swift */,
 				29A4769F1ED0E6C6005D0953 /* UIColor+Overlay.swift */,
 				295B51471FC26F7F00C3993B /* UIImageView+Avatar.swift */,
+				29136BDE200A7A75007317BE /* UIScrollView+LeftRightSafeInset.swift */,
 				290744B91F26863100FD9E48 /* UIScrollView+ScrollToBottom.swift */,
 				294B11211F7B0B9500E04F2D /* UIScrollView+ScrollToTop.swift */,
 				294A3D771FB29E2A000E81A4 /* UISearchBar+Keyboard.swift */,
 				29AF1E831F8AAB4A0008A0EF /* UITextView+GitHawk.swift */,
 				292FF8B11F302FE7009E63F7 /* UITextView+SelectedRange.swift */,
 				298BA08E1EC90FEE00B01946 /* UIView+BottomBorder.swift */,
-				29136BDA200A626D007317BE /* FixedRefreshControl.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2507,6 +2510,7 @@
 				2905AFAB1F7357B40015AE32 /* RepositoryOverviewViewController.swift in Sources */,
 				29EDFE821F661562005BCCEB /* RepositoryReadmeModel.swift in Sources */,
 				29EDFE841F661776005BCCEB /* RepositoryReadmeSectionController.swift in Sources */,
+				29136BDF200A7A75007317BE /* UIScrollView+LeftRightSafeInset.swift in Sources */,
 				986B87381F2CB29700AAB55C /* RepositorySummaryCell.swift in Sources */,
 				986B87361F2CB28C00AAB55C /* RepositorySummarySectionController.swift in Sources */,
 				2905AFAF1F7357FA0015AE32 /* RepositoryViewController.swift in Sources */,

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		290EF56A1F06A821006A2160 /* Notification+NotificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290EF5691F06A7E1006A2160 /* Notification+NotificationViewModel.swift */; };
 		290EF5761F06BA06006A2160 /* NoNewNotificationsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290EF5751F06BA06006A2160 /* NoNewNotificationsCell.swift */; };
 		290EF5791F06BAF4006A2160 /* NoNewNotificationsSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290EF5781F06BAF4006A2160 /* NoNewNotificationsSectionController.swift */; };
+		29136BDB200A626D007317BE /* FixedRefreshControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29136BDA200A626D007317BE /* FixedRefreshControl.swift */; };
+		29136BDD200A6C40007317BE /* IssueTitleModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29136BDC200A6C40007317BE /* IssueTitleModel.swift */; };
 		291929421F3EA8CD0012067B /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291929411F3EA8CD0012067B /* File.swift */; };
 		291929471F3EAB250012067B /* IssueDetailsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291929461F3EAB250012067B /* IssueDetailsModel.swift */; };
 		291929491F3EAD2E0012067B /* IssueViewFilesSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291929481F3EAD2E0012067B /* IssueViewFilesSectionController.swift */; };
@@ -445,6 +447,8 @@
 		290EF5691F06A7E1006A2160 /* Notification+NotificationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+NotificationViewModel.swift"; sourceTree = "<group>"; };
 		290EF5751F06BA06006A2160 /* NoNewNotificationsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoNewNotificationsCell.swift; sourceTree = "<group>"; };
 		290EF5781F06BAF4006A2160 /* NoNewNotificationsSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoNewNotificationsSectionController.swift; sourceTree = "<group>"; };
+		29136BDA200A626D007317BE /* FixedRefreshControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedRefreshControl.swift; sourceTree = "<group>"; };
+		29136BDC200A6C40007317BE /* IssueTitleModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueTitleModel.swift; sourceTree = "<group>"; };
 		291929411F3EA8CD0012067B /* File.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
 		291929461F3EAB250012067B /* IssueDetailsModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueDetailsModel.swift; sourceTree = "<group>"; };
 		291929481F3EAD2E0012067B /* IssueViewFilesSectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueViewFilesSectionController.swift; sourceTree = "<group>"; };
@@ -1109,6 +1113,7 @@
 			children = (
 				292FCAF41EDFCC510026635E /* IssueTitleCell.swift */,
 				292FCAF51EDFCC510026635E /* IssueTitleSectionController.swift */,
+				29136BDC200A6C40007317BE /* IssueTitleModel.swift */,
 			);
 			path = Title;
 			sourceTree = "<group>";
@@ -1505,6 +1510,7 @@
 				29AF1E831F8AAB4A0008A0EF /* UITextView+GitHawk.swift */,
 				292FF8B11F302FE7009E63F7 /* UITextView+SelectedRange.swift */,
 				298BA08E1EC90FEE00B01946 /* UIView+BottomBorder.swift */,
+				29136BDA200A626D007317BE /* FixedRefreshControl.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2424,6 +2430,7 @@
 				292FCB181EDFCC510026635E /* IssueTitleCell.swift in Sources */,
 				292FCB191EDFCC510026635E /* IssueTitleSectionController.swift in Sources */,
 				294563F01EE5036A00DBCD35 /* IssueType.swift in Sources */,
+				29136BDD200A6C40007317BE /* IssueTitleModel.swift in Sources */,
 				2919294B1F3EAD890012067B /* IssueViewFilesCell.swift in Sources */,
 				291929491F3EAD2E0012067B /* IssueViewFilesSectionController.swift in Sources */,
 				292FCB101EDFCC510026635E /* IssueViewModels.swift in Sources */,
@@ -2476,6 +2483,7 @@
 				298003401F51E93B00BE90F4 /* RatingCell.swift in Sources */,
 				2980033C1F51E82400BE90F4 /* RatingController.swift in Sources */,
 				29B94E671FCB2D4600715D7E /* CodeView.swift in Sources */,
+				29136BDB200A626D007317BE /* FixedRefreshControl.swift in Sources */,
 				2980033E1F51E93500BE90F4 /* RatingSectionController.swift in Sources */,
 				29FF85A51EE1EA7A007B8762 /* ReactionContent+ReactionType.swift in Sources */,
 				292FCB1D1EDFCD3D0026635E /* ReactionViewModel.swift in Sources */,

--- a/Local Pods/MessageViewController/MessageViewController/MessageViewController.swift
+++ b/Local Pods/MessageViewController/MessageViewController/MessageViewController.swift
@@ -161,7 +161,7 @@ open class MessageViewController: UIViewController, MessageAutocompleteControlle
 
         UIView.animate(withDuration: animationDuration) {
             // capture before changing the frame which might have weird side effects
-            let contentOffset = self.scrollView.contentOffset.y
+            let contentOffset = self.scrollView.contentOffset
 
             self.layout()
 
@@ -173,11 +173,11 @@ open class MessageViewController: UIViewController, MessageAutocompleteControlle
             let newOffset = max(
                 min(
                     contentHeight - scrollViewHeight,
-                    contentOffset + self.keyboardHeight - previousKeyboardHeight - bottomSafeInset
+                    contentOffset.y + self.keyboardHeight - previousKeyboardHeight - bottomSafeInset
                 ),
                 -topInset
             )
-            self.scrollView.contentOffset = CGPoint(x: 0, y: newOffset)
+            self.scrollView.contentOffset = CGPoint(x: contentOffset.x, y: newOffset)
         }
     }
 


### PR DESCRIPTION
- [x] Use `contentInset` to set a baseline inset for all content in threads (issues/PRs and PR reviews)
- [x] Fix layout bug in `UIRefreshControl`
- [x] Ensure that text caches are always hit for warmed caches
- [x] Redesign header padding for more breathing room
- [x] Larger title font
- [ ] Fix safe area bugs for landscape on X

