### PR TITLE
Make edit comment keyboard use the Twitter style

### DIFF
--- a/Classes/Issues/EditComment/EditCommentViewController.swift
+++ b/Classes/Issues/EditComment/EditCommentViewController.swift
@@ -68,6 +68,7 @@ MessageTextViewListener {
         )
 
         textView.githawkConfigure(inset: true)
+        textView.keyboardType = .twitter
         view.addSubview(textView)
         textView.snp.makeConstraints { make in
             make.edges.equalTo(view)


### PR DESCRIPTION
Fixes #627 

<img width="433" alt="screen shot 2018-01-13 at 20 45 40" src="https://user-images.githubusercontent.com/4190298/34909511-dccbdb24-f8a2-11e7-9db5-28513a466410.png">