### PR TITLE
Distinguish owner from repository in dropdown actionsheet

### DIFF
--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -244,7 +244,7 @@ IssueManagingNavSectionControllerDelegate {
     func viewOwnerAction() -> UIAlertAction? {
         weak var weakSelf = self
         return AlertAction(AlertActionBuilder { $0.rootViewController = weakSelf })
-            .view(owner: model.owner)
+            .view(owner: "@\(model.owner)")
     }
 
     func viewRepoAction() -> UIAlertAction? {

--- a/FreetimeTests/MMMarkdownASTTests.swift
+++ b/FreetimeTests/MMMarkdownASTTests.swift
@@ -18,7 +18,7 @@ final class MMMarkdownASTTests: XCTestCase {
     }
 
     func test_fileExists() {
-        XCTAssertTrue(testMarkdown.characters.count > 0)
+        XCTAssertTrue(testMarkdown.count > 0)
     }
 
     func test_createASTWorks() {


### PR DESCRIPTION
Fixes #1408 

Also fixes a warning in the test suite.

<img width="433" alt="screen shot 2018-01-14 at 10 14 07" src="https://user-images.githubusercontent.com/4190298/34914481-e6951a5a-f913-11e7-8b55-f26cd1a667b3.png">