### PR TITLE
Adds (better) a11x to Pulll Request reply

### DIFF
--- a/Classes/PullRequestReviews/PullRequestReviewReplyCell.swift
+++ b/Classes/PullRequestReviews/PullRequestReviewReplyCell.swift
@@ -15,9 +15,14 @@ final class PullRequestReviewReplyCell: IssueCommentBaseCell {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        isAccessibilityElement = true
+        accessibilityTraits |= UIAccessibilityTraitButton
+
+        let buttonTitle = NSLocalizedString("Reply", comment: "")
+        accessibilityLabel = buttonTitle
 
         let color = Styles.Colors.Blue.medium.color
-        button.setTitle(NSLocalizedString("Reply", comment: ""), for: .normal)
+        button.setTitle(buttonTitle, for: .normal)
         button.setImage(UIImage(named: "reply")?.withRenderingMode(.alwaysTemplate), for: .normal)
         button.tintColor = color
         button.setTitleColor(color, for: .normal)


### PR DESCRIPTION
Old:
<img width="1154" alt="oldi" src="https://user-images.githubusercontent.com/4190298/35781468-c5a26734-09ea-11e8-9410-c76044b42a7e.png">
<img width="517" alt="old" src="https://user-images.githubusercontent.com/4190298/35781469-c5c0132e-09ea-11e8-8a94-a2123ff4db2d.png">

New:
<img width="1126" alt="screen shot 2018-02-04 at 20 30 29" src="https://user-images.githubusercontent.com/4190298/35781472-cd2ce13c-09ea-11e8-9eb9-19be174f9cb1.png">
<img width="545" alt="screen shot 2018-02-04 at 20 30 24" src="https://user-images.githubusercontent.com/4190298/35781473-cd42233a-09ea-11e8-805a-34c9f5f98638.png">

(Feel free to ignore the underlined buttons - that's button shapes for you)