### PR TITLE
Fix star count label compression #1505

### DIFF
--- a/Classes/Search/SearchRepoResultCell.swift
+++ b/Classes/Search/SearchRepoResultCell.swift
@@ -70,6 +70,7 @@ final class SearchRepoResultCell: SelectableCell {
             make.right.equalTo(languageLabel)
         }
 
+        descriptionLabel.setContentCompressionResistancePriority(UILayoutPriority.defaultLow, for: .horizontal)
         descriptionLabel.font = Styles.Text.secondary.preferredFont
         descriptionLabel.textColor = Styles.Colors.Gray.light.color
         descriptionLabel.snp.makeConstraints { make in


### PR DESCRIPTION
This resolves #1505 by setting a lower horizontal compression priority on the repo's description label. Just a small PR to break the ice here. Better to fix things than be the guy complaining all the time 😃 

<img width="321" alt="screen shot 2018-02-10 at 12 39 57 am" src="https://user-images.githubusercontent.com/7445580/36059294-04f7b6a0-0dfb-11e8-9d92-e946fcf4705d.png">