### PR TITLE
Add mention shortcut to IssueTextActionsView

### DIFF
--- a/Classes/Issues/EditComment/EditCommentViewController.swift
+++ b/Classes/Issues/EditComment/EditCommentViewController.swift
@@ -68,7 +68,6 @@ MessageTextViewListener {
         )
 
         textView.githawkConfigure(inset: true)
-        textView.keyboardType = .twitter
         view.addSubview(textView)
         textView.snp.makeConstraints { make in
             make.edges.equalTo(view)

--- a/Classes/Views/IssueTextActionsView+Markdown.swift
+++ b/Classes/Views/IssueTextActionsView+Markdown.swift
@@ -27,6 +27,10 @@ extension IssueTextActionsView {
             }),
                 name: NSLocalizedString("Message Preview", comment: "The name of the action for previewing a message from the markdown actions bar")),
             IssueTextActionOperation(
+                icon: UIImage(named: "mention"),
+                operation: .line("@"),
+                name: NSLocalizedString("Add mention to text", comment: "The name of the action for making text a mention from the markdown actions bar")),
+            IssueTextActionOperation(
                 icon: UIImage(named: "bar-bold"),
                 operation: .wrap("**", "**"),
                 name: NSLocalizedString("Make text bold", comment: "The name of the action for making text bold from the markdown actions bar")),

--- a/Classes/Views/MessageView+Styles.swift
+++ b/Classes/Views/MessageView+Styles.swift
@@ -16,7 +16,6 @@ extension MessageViewController {
         borderColor = Styles.Colors.Gray.border.color
         messageView.textView.placeholderText = NSLocalizedString("Leave a comment", comment: "")
         messageView.textView.placeholderTextColor = Styles.Colors.Gray.light.color
-        messageView.keyboardType = .twitter
         messageView.set(buttonIcon: UIImage(named: "send")?.withRenderingMode(.alwaysTemplate), for: .normal)
         messageView.buttonTint = Styles.Colors.Blue.medium.color
         messageView.font = Styles.Text.body.preferredFont


### PR DESCRIPTION
Resolves #1481 

This adds the `@` mention symbol as a shortcut to `IssueTextActionsView`. I've also changed the `UIKeyboardType` from `.twitter` to `.default`, so we regain the return key.

The `.twitter` keyboard makes it very easy to add both `#` and `@`. 
Do we want to wait for #219 to add `#`?

### Image:
<img width="378" alt="screen shot 2018-02-10 at 1 23 34 am" src="https://user-images.githubusercontent.com/7445580/36059609-13b4b138-0e01-11e8-857d-ee25fed29293.png">
