### PR TITLE
Display paste menu on URL wrapping

### DIFF
--- a/Classes/Issues/IssueTextActionsView.swift
+++ b/Classes/Issues/IssueTextActionsView.swift
@@ -58,6 +58,7 @@ struct IssueTextActionOperation {
         case line(String)
         case wrap(String, String)
         case execute(() -> Void)
+        case multi([Operation])
         case uploadImage
     }
 

--- a/Classes/Views/IssueTextActionsView+Markdown.swift
+++ b/Classes/Views/IssueTextActionsView+Markdown.swift
@@ -64,7 +64,14 @@ extension IssueTextActionsView {
                 name: NSLocalizedString("Make text indented", comment: "The name of the action for making text indented from the markdown actions bar")),
             IssueTextActionOperation(
                 icon: UIImage(named: "bar-link"),
-                operation: .wrap("[", "](\(UITextView.cursorToken))"),
+                operation: .multi([
+                    .wrap("[", "](\(UITextView.cursorToken))"),
+                    .execute({
+                        if UIPasteboard.general.hasURLs {
+                            UIMenuController.shared.setMenuVisible(true, animated: trueUnlessReduceMotionEnabled)
+                        }
+                    })
+                ]),
                 name: NSLocalizedString("Wrap text as URL", comment: "The name of the action to wrap text in a markdown URL from the markdown actions bar"))
         ]
 

--- a/Classes/Views/TextActionsController.swift
+++ b/Classes/Views/TextActionsController.swift
@@ -29,19 +29,21 @@ final class TextActionsController: NSObject,
     // MARK: IssueTextActionsViewDelegate
 
     func didSelect(actionsView: IssueTextActionsView, operation: IssueTextActionOperation) {
-        switch operation.operation {
-        case .wrap(let left, let right):
-            textView?.replace(left: left, right: right, atLineStart: false)
-            if operation.name == "Wrap text as URL" && UIPasteboard.general.hasURLs {
-                UIMenuController.shared.setMenuVisible(true, animated: trueUnlessReduceMotionEnabled)
+        func handle(_ operation: IssueTextActionOperation.Operation) {
+            switch operation {
+            case .wrap(let left, let right):
+                textView?.replace(left: left, right: right, atLineStart: false)
+            case .line(let left):
+                textView?.replace(left: left, right: nil, atLineStart: true)
+            case .execute(let block):
+                block()
+            case .uploadImage:
+                displayUploadImage()
+            case .multi(let operations):
+                operations.forEach { handle($0) }
             }
-        case .line(let left):
-            textView?.replace(left: left, right: nil, atLineStart: true)
-        case .execute(let block):
-            block()
-        case .uploadImage:
-            displayUploadImage()
         }
+        handle(operation.operation)
     }
 
     // MARK: Image Upload

--- a/Classes/Views/TextActionsController.swift
+++ b/Classes/Views/TextActionsController.swift
@@ -30,10 +30,17 @@ final class TextActionsController: NSObject,
 
     func didSelect(actionsView: IssueTextActionsView, operation: IssueTextActionOperation) {
         switch operation.operation {
-        case .execute(let block): block()
-        case .wrap(let left, let right): textView?.replace(left: left, right: right, atLineStart: false)
-        case .line(let left): textView?.replace(left: left, right: nil, atLineStart: true)
-        case .uploadImage: displayUploadImage()
+        case .wrap(let left, let right):
+            textView?.replace(left: left, right: right, atLineStart: false)
+            if operation.name == "Wrap text as URL" && UIPasteboard.general.hasURLs {
+                UIMenuController.shared.setMenuVisible(true, animated: trueUnlessReduceMotionEnabled)
+            }
+        case .line(let left):
+            textView?.replace(left: left, right: nil, atLineStart: true)
+        case .execute(let block):
+            block()
+        case .uploadImage:
+            displayUploadImage()
         }
     }
 


### PR DESCRIPTION
Resolves #1453 

This PR does the following:
- Automatically displays the paste menu upon using the link markdown action if the `UIPasteboard` contains a `URL`
- Refactors the order of the `switch` statement to check more frequent `Operation`s first

If this is too much of a hack I can try to create an indirect enum that allows both a `.wrap` and `.execute` but why get fancy until it's necessary?