### PR TITLE
Check if default value is for client ID and secret is set

### DIFF
--- a/Freetime.xcodeproj/xcshareddata/xcschemes/Freetime-AppCenter.xcscheme
+++ b/Freetime.xcodeproj/xcshareddata/xcschemes/Freetime-AppCenter.xcscheme
@@ -81,23 +81,8 @@
             isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "GITHUB_CLIENT_SECRET"
-            value = "SET ON CI"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
             key = "NETWORK_RECORD_PATH"
             value = "$(PROJECT_DIR)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "GITHUB_CLIENT_ID"
-            value = "SET ON CI"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "IMGUR_CLIENT_ID"
-            value = "SET ON CI"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>


### PR DESCRIPTION
Fixes #1535 

## What this does
Removes the pre-configured GitHub client ID and secret. This has the advantage that if the user doesn't have them set in their environment an explicit error message will be displayed. 

