### PR TITLE
Release notifications

### DIFF
--- a/Classes/Bookmark/BookmarkViewModel.swift
+++ b/Classes/Bookmark/BookmarkViewModel.swift
@@ -36,6 +36,9 @@ final class BookmarkViewModel: ListDiffable {
                 ]
             ))
             attributedText = mAttributedText
+        case .release:
+            // TODO does this even exist?
+            attributedText = NSAttributedString(string: bookmark.title, attributes: attributes)
         }
 
         text = NSAttributedStringSizing(

--- a/Classes/Notifications/Notification+NotificationViewModel.swift
+++ b/Classes/Notifications/Notification+NotificationViewModel.swift
@@ -15,9 +15,13 @@ extension String {
         guard split.count > 2,
             let identifier = split.last
             else { return nil }
-        if split[split.count - 2] == "commits" {
+        let type = split[split.count - 2]
+        switch type {
+        case "commits":
             return .hash(identifier)
-        } else {
+        case "releases":
+            return .release(identifier)
+        default:
             return .number((identifier as NSString).integerValue)
         }
     }
@@ -58,28 +62,7 @@ func CreateNotificationViewModels(
     completion: @escaping ([NotificationViewModel]) -> Void
     ) {
     DispatchQueue.global().async {
-        var viewModels = [NotificationViewModel]()
-
-        for notification in notifications {
-            guard let type = NotificationType(rawValue: notification.subject.type),
-                let date = notification.updated_at.githubDate,
-                let identifier = notification.subject.url.notificationIdentifier
-                else { continue }
-
-            let model = NotificationViewModel(
-                id: notification.id,
-                title: notification.subject.title,
-                type: type,
-                date: date,
-                read: !notification.unread,
-                owner: notification.repository.owner.login,
-                repo: notification.repository.name,
-                identifier: identifier,
-                containerWidth: containerWidth
-            )
-            viewModels.append(model)
-        }
-
+        let viewModels = CreateViewModels(containerWidth: containerWidth, notifications: notifications)
         DispatchQueue.main.async {
             completion(viewModels)
         }

--- a/Classes/Notifications/NotificationClient.swift
+++ b/Classes/Notifications/NotificationClient.swift
@@ -12,8 +12,8 @@ import Foundation
 extension NotificationViewModel {
     var stateAlias: (number: Int, key: String)? {
         switch identifier {
-        case .hash:
-            // commits don't have states, always merged
+        case .hash, .release:
+            // commits and releases don't have states, always "merged"
             return nil
         case .number(let number):
             // graphQL alias must be an alpha-numeric string and start w/ alpha

--- a/Classes/Notifications/NotificationClient.swift
+++ b/Classes/Notifications/NotificationClient.swift
@@ -199,6 +199,19 @@ final class NotificationClient {
         })
     }
 
+    func fetchReleaseTag(owner: String, repo: String, id: String, completion: @escaping (Result<String>) -> Void) {
+        githubClient.request(GithubClient.Request(
+            path: "repos/\(owner)/\(repo)/releases/\(id)"
+        ) { response, _ in
+            if let json = response.value as? [String: Any],
+                let tag = json["tag_name"] as? String {
+                completion(.success(tag))
+            } else {
+                completion(.error(response.error))
+            }
+        })
+    }
+
     // MARK: Private API
 
     func path(repo: NotificationRepository?) -> String {

--- a/Classes/Notifications/NotificationSectionController.swift
+++ b/Classes/Notifications/NotificationSectionController.swift
@@ -64,7 +64,18 @@ SwipeCollectionViewCellDelegate {
             let navigation = UINavigationController(rootViewController: controller)
             viewController?.showDetailViewController(navigation, sender: nil)
         case .release(let release):
-            viewController?.presentRelease(owner: object.owner, repo: object.repo, release: release)
+            client.fetchReleaseTag(
+                owner: object.owner,
+                repo: object.repo,
+                id: release,
+                completion: { [weak self] (result) in
+                    switch result {
+                    case .success(let tag):
+                        self?.viewController?.presentRelease(owner: object.owner, repo: object.repo, release: tag)
+                    case .error:
+                        ToastManager.showGenericError()
+                    }
+            })
         }
     }
 

--- a/Classes/Notifications/NotificationSectionController.swift
+++ b/Classes/Notifications/NotificationSectionController.swift
@@ -63,6 +63,8 @@ SwipeCollectionViewCellDelegate {
             )
             let navigation = UINavigationController(rootViewController: controller)
             viewController?.showDetailViewController(navigation, sender: nil)
+        case .release(let release):
+            viewController?.presentRelease(owner: object.owner, repo: object.repo, release: release)
         }
     }
 

--- a/Classes/Notifications/NotificationType+Icon.swift
+++ b/Classes/Notifications/NotificationType+Icon.swift
@@ -17,6 +17,7 @@ extension NotificationType {
         case .commit: image = #imageLiteral(resourceName: "git-commit")
         case .issue: image = #imageLiteral(resourceName: "issue-opened")
         case .pullRequest: image = #imageLiteral(resourceName: "git-pull-request")
+        case .release: image = #imageLiteral(resourceName: "tag")
         }
 
         return image

--- a/Classes/Notifications/NotificationType.swift
+++ b/Classes/Notifications/NotificationType.swift
@@ -14,16 +14,15 @@ enum NotificationType: String {
     case pullRequest = "PullRequest"
     case commit = "Commit"
     case repo = "Repository"
-}
-
-extension NotificationType {
+    case release = "Release"
 
     var localizedString: String {
         switch self {
-        case .issue, .commit, .repo:
-            return NSLocalizedString(self.rawValue, comment: "")
-        case .pullRequest:
-            return Constants.Strings.pullRequest
+        case .issue: return Constants.Strings.issue
+        case .commit: return NSLocalizedString("Commit", comment: "")
+        case .repo: return NSLocalizedString("Repository", comment: "")
+        case .release: return NSLocalizedString("Release", comment: "")
+        case .pullRequest: return Constants.Strings.pullRequest
         }
     }
 }

--- a/Classes/Notifications/NotificationViewModel.swift
+++ b/Classes/Notifications/NotificationViewModel.swift
@@ -15,6 +15,7 @@ final class NotificationViewModel: ListDiffable, Cachable {
     enum Identifier {
         case number(Int)
         case hash(String)
+        case release(String)
     }
 
     // combining possible issue and PR states

--- a/Classes/View Controllers/UIViewController+Safari.swift
+++ b/Classes/View Controllers/UIViewController+Safari.swift
@@ -25,6 +25,11 @@ extension UIViewController {
         presentSafari(url: url)
     }
 
+    func presentRelease(owner: String, repo: String, release: String) {
+        guard let url = URL(string: "https://github.com/\(owner)/\(repo)/releases/tag/\(release)") else { return }
+        presentSafari(url: url)
+    }
+
     func presentLabels(owner: String, repo: String, label: String) {
         guard let url = URL(string: "https://github.com/\(owner)/\(repo)/labels/\(label)") else { return }
         presentSafari(url: url)


### PR DESCRIPTION
Only thing I can't quite figure out is how to link to it... We get an API path that we can extract the id from, like this:

https://api.github.com/repos/facebook/Docusaurus/releases/9721470

Where `9721470` is the ID. But I'm not sure how to link it to [the actual release](https://github.com/facebook/Docusaurus/releases/tag/v1.0.7).

Any ideas?

Shot of it working:

![simulator screen shot - iphone x - 2018-02-19 at 22 32 26](https://user-images.githubusercontent.com/739696/36406461-00d1eb28-15c5-11e8-8f45-e633ce081537.png)
