### PR TITLE
Move API stringiness to client

### DIFF
--- a/Classes/Issues/Comments/IssueCommentSectionController.swift
+++ b/Classes/Issues/Comments/IssueCommentSectionController.swift
@@ -70,7 +70,7 @@ IssueCommentDoubleTapDelegate {
     func shareAction(sender: UIView) -> UIAlertAction? {
         let attribute = object?.asReviewComment == true ? "#discussion_r" : "#issuecomment-"
         guard let number = object?.number,
-            let url = URL(string: "https://github.com/\(model.owner)/\(model.repo)/issues/\(model.number)\(attribute)\(number)")
+            let url = GithubClient.url(path: "\(model.owner)/\(model.repo)/issues/\(model.number)\(attribute)\(number)")
         else { return nil }
         weak var weakSelf = self
 

--- a/Classes/Issues/Comments/Markdown/CommentModelsFromMarkdown.swift
+++ b/Classes/Issues/Comments/Markdown/CommentModelsFromMarkdown.swift
@@ -191,7 +191,7 @@ func createModel(
 
         let baseURL: URL?
         if options.flavors.contains(.baseURL) {
-            baseURL = URL(string: "https://github.com/\(options.owner)/\(options.repo)/raw/master/")
+            baseURL = GithubClient.url(path: "\(options.owner)/\(options.repo)/raw/master/")
         } else {
             baseURL = nil
         }

--- a/Classes/Issues/EditComment/GithubClient+EditComment.swift
+++ b/Classes/Issues/EditComment/GithubClient+EditComment.swift
@@ -24,7 +24,7 @@ extension GithubClient {
             ? "repos/\(owner)/\(repo)/issues/\(issueNumber)"
             // https://developer.github.com/v3/issues/comments/#edit-a-comment
             : "repos/\(owner)/\(repo)/issues/comments/\(commentID)"
-        request(Request(
+        request(Request.api(
             path: path,
             method: .patch,
             parameters: ["body": body],

--- a/Classes/Issues/Files/GithubClient+PullRequestFiles.swift
+++ b/Classes/Issues/Files/GithubClient+PullRequestFiles.swift
@@ -17,7 +17,7 @@ extension GithubClient {
         page: Int,
         completion: @escaping (Result<([File], Int?)>) -> Void
         ) {
-        request(Request(
+        request(Request.api(
             path: "repos/\(owner)/\(repo)/pulls/\(number)/files",
             parameters: [
                 "per_page": 50,
@@ -37,40 +37,4 @@ extension GithubClient {
                 }
         }))
     }
-
-    func fetchContents(
-        contentsURLString: String,
-        completion: @escaping (Result<(NSAttributedStringSizing, Content)>) -> Void
-        ) {
-        request(Request(url: contentsURLString, completion: { (response, _) in
-            if let json = response.value as? [String: Any] {
-                DispatchQueue.global().async {
-                    if let content = Content(json: json),
-                        let data = Data(base64Encoded: content.content, options: [.ignoreUnknownCharacters]),
-                        let text = String(data: data, encoding: .utf8) {
-                        let attributes = [
-                            NSAttributedStringKey.font: Styles.Text.code.preferredFont,
-                            NSAttributedStringKey.foregroundColor: Styles.Colors.Gray.dark.color
-                        ]
-                        let attributedText = NSAttributedString(string: text, attributes: attributes)
-                        let sizing = NSAttributedStringSizing(
-                            containerWidth: 0,
-                            attributedText: attributedText,
-                            inset: Styles.Sizes.textViewInset
-                        )
-                        DispatchQueue.main.async {
-                            completion(.success((sizing, content)))
-                        }
-                    } else {
-                        DispatchQueue.main.async {
-                            completion(.error(nil))
-                        }
-                    }
-                }
-            } else {
-                completion(.error(nil))
-            }
-        }))
-    }
-
 }

--- a/Classes/Issues/GithubClient+Issues.swift
+++ b/Classes/Issues/GithubClient+Issues.swift
@@ -205,7 +205,7 @@ extension GithubClient {
         let stateString = close ? "closed" : "open"
 
         // https://developer.github.com/v3/issues/#edit-an-issue
-        request(Request(
+        request(Request.api(
             path: "repos/\(owner)/\(repo)/issues/\(number)",
             method: .patch,
             parameters: [ "state": stateString ],
@@ -219,7 +219,7 @@ extension GithubClient {
     }
 
     func deleteComment(owner: String, repo: String, commentID: Int, completion: @escaping (Result<Bool>) -> Void) {
-        request(Request(path: "repos/\(owner)/\(repo)/issues/comments/\(commentID)", method: .delete, completion: { (response, _) in
+        request(Request.api(path: "repos/\(owner)/\(repo)/issues/comments/\(commentID)", method: .delete, completion: { (response, _) in
             // As per documentation this endpoint returns no content, so all we can validate is that
             // the status code is "204 No Content".
             if response.response?.statusCode == 204 {
@@ -261,7 +261,7 @@ extension GithubClient {
         // optimistically update the cache, listeners can react as appropriate
         cache.set(value: optimisticResult)
 
-        request(Request(
+        request(Request.api(
             path: "repos/\(owner)/\(repo)/issues/\(number)/lock",
             method: locked ? .put : .delete,
             completion: { (response, _) in
@@ -308,7 +308,7 @@ extension GithubClient {
         }
 
         // https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level
-        request(Request(
+        request(Request.api(
             path: "repos/\(owner)/\(repo)/collaborators/\(viewer)/permission",
             headers: ["Accept": "application/vnd.github.hellcat-preview+json"],
             completion: { (response, _) in
@@ -377,7 +377,7 @@ extension GithubClient {
         let cache = self.cache
         cache.set(value: optimistic)
 
-        request(GithubClient.Request(
+        request(GithubClient.Request.api(
             path: "repos/\(owner)/\(repo)/issues/\(number)",
             method: .patch,
             parameters: ["labels": labels.map { $0.name }]
@@ -489,7 +489,7 @@ extension GithubClient {
         // https://developer.github.com/v3/issues/assignees/#add-assignees-to-an-issue
         // https://developer.github.com/v3/pulls/review_requests/#create-a-review-request
         if added.count > 0 {
-            request(GithubClient.Request(
+            request(GithubClient.Request.api(
                 path: path,
                 method: .post,
                 parameters: [param: added]
@@ -501,7 +501,7 @@ extension GithubClient {
         // https://developer.github.com/v3/issues/assignees/#remove-assignees-from-an-issue
         // https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request
         if removed.count > 0 {
-            request(GithubClient.Request(
+            request(GithubClient.Request.api(
                 path: path,
                 method: .delete,
                 parameters: [param: removed]

--- a/Classes/Issues/IssuesViewController.swift
+++ b/Classes/Issues/IssuesViewController.swift
@@ -206,7 +206,7 @@ IssueManagingNavSectionControllerDelegate {
     }
 
     var externalURL: URL {
-        return URL(string: "https://github.com/\(model.owner)/\(model.repo)/issues/\(model.number)")!
+        return GithubClient.url(path: "\(model.owner)/\(model.repo)/issues/\(model.number)")!
     }
 
     var bookmark: Bookmark? {

--- a/Classes/Issues/Merge/GithubClient+Merge.swift
+++ b/Classes/Issues/Merge/GithubClient+Merge.swift
@@ -46,7 +46,7 @@ extension GithubClient {
         let cache = self.cache
 
         // https://developer.github.com/v3/issues/#edit-an-issue
-        request(Request(
+        request(Request.api(
             path: "repos/\(owner)/\(repo)/pulls/\(number)/merge",
             method: .put,
             parameters: [ "merge_method": methodString ],

--- a/Classes/Login/GithubClient+AccessToken.swift
+++ b/Classes/Login/GithubClient+AccessToken.swift
@@ -27,8 +27,8 @@ extension GithubClient {
         let headers = [
             "Accept": "application/json"
         ]
-        request(Request(
-            url: "https://github.com/login/oauth/access_token",
+        request(Request.site(
+            path: "login/oauth/access_token",
             method: .post,
             parameters: parameters,
             headers: headers,
@@ -58,8 +58,8 @@ extension GithubClient {
             "Accept": "application/json",
             "Authorization": "token \(token)"
         ]
-        request(Request(
-            url: "https://api.github.com/user",
+        request(Request.api(
+            path: "user",
             method: .get,
             headers: headers,
             logoutOnAuthFailure: false,

--- a/Classes/Login/LoginSplashViewController.swift
+++ b/Classes/Login/LoginSplashViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import SafariServices
 
-private let loginURL = URL(string: "http://github.com/login/oauth/authorize?client_id=\(Secrets.GitHub.clientId)&scope=user+repo+notifications")!
+private let loginURL = GithubClient.url(path: "login/oauth/authorize?client_id=\(Secrets.GitHub.clientId)&scope=user+repo+notifications")!
 private let callbackURLScheme = "freetime://"
 
 final class LoginSplashViewController: UIViewController, GithubSessionListener {

--- a/Classes/Milestones/GithubClient+Milestones.swift
+++ b/Classes/Milestones/GithubClient+Milestones.swift
@@ -15,7 +15,7 @@ extension GithubClient {
         repo: String,
         completion: @escaping (Result<[Milestone]>) -> Void
         ) {
-        request(GithubClient.Request(
+        request(GithubClient.Request.api(
             path: "repos/\(owner)/\(repo)/milestones"
         ) { (response, _) in
             if let jsonArr = response.value as? [[String: Any]] {
@@ -84,7 +84,7 @@ extension GithubClient {
         cache.set(value: optimisticResult)
 
         // https://developer.github.com/v3/issues/#edit-an-issue
-        request(Request(
+        request(Request.api(
             path: "repos/\(owner)/\(repo)/issues/\(number)",
             method: .patch,
             parameters: [ "milestone": milestone?.number ?? NSNull() ],

--- a/Classes/New Issue/GitHubClient+NewIssue.swift
+++ b/Classes/New Issue/GitHubClient+NewIssue.swift
@@ -27,7 +27,7 @@ extension GithubClient {
             completion(model)
         }
 
-        request(Request(path: "repos/\(owner)/\(repo)/issues",
+        request(Request.api(path: "repos/\(owner)/\(repo)/issues",
                         method: .post,
                         parameters: params,
                         headers: nil,

--- a/Classes/Notifications/NotificationClient.swift
+++ b/Classes/Notifications/NotificationClient.swift
@@ -73,7 +73,7 @@ final class NotificationClient {
             parameters["before"] = GithubAPIDateFormatter().string(from: before)
         }
 
-        githubClient.request(GithubClient.Request(
+        githubClient.request(GithubClient.Request.api(
             path: path(repo: repo),
             method: .get,
             parameters: parameters,
@@ -161,7 +161,7 @@ final class NotificationClient {
             }
         }
 
-        githubClient.request(GithubClient.Request(
+        githubClient.request(GithubClient.Request.api(
             path: "notifications/threads/\(id)",
             method: .patch) { [weak self] response, _ in
                 // https://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read
@@ -181,7 +181,7 @@ final class NotificationClient {
             return
         }
 
-        githubClient.request(GithubClient.Request(
+        githubClient.request(GithubClient.Request.api(
             path: "users/\(viewer)/subscriptions"
         ) { response, _ in
             // https://developer.github.com/v3/activity/watching/#list-repositories-being-watched
@@ -210,7 +210,7 @@ final class NotificationClient {
     }
 
     func markNotifications(repo: NotificationRepository? = nil, completion: @escaping (Bool) -> Void) {
-        githubClient.request(GithubClient.Request(
+        githubClient.request(GithubClient.Request.api(
             path: path(repo: repo),
             method: .put
         ) { response, _ in

--- a/Classes/People/GithubClient+People.swift
+++ b/Classes/People/GithubClient+People.swift
@@ -16,7 +16,7 @@ extension GithubClient {
         completion: @escaping (Result<[User]>) -> Void
         ) {
         // https://developer.github.com/v3/issues/assignees/#list-assignees
-        request(GithubClient.Request(
+        request(GithubClient.Request.api(
             path: "repos/\(owner)/\(repo)/assignees"
         ) { (response, _) in
             if let jsonArr = response.value as? [[String: Any]] {

--- a/Classes/PullRequestReviews/GithubClient+PullRequestReviewComments.swift
+++ b/Classes/PullRequestReviews/GithubClient+PullRequestReviewComments.swift
@@ -27,7 +27,7 @@ extension GithubClient {
         completion: @escaping (Result<([ListDiffable], Int?)>) -> ()
         ) {
         let viewerUsername = userSession?.username
-        request(Request(
+        request(Request.api(
             path: "repos/\(owner)/\(repo)/pulls/\(number)/comments",
             completion: { (response, nextPage) in
 
@@ -117,7 +117,7 @@ extension GithubClient {
         let viewer = userSession?.username
 
         // https://developer.github.com/v3/pulls/comments/#alternative-input
-        request(Request(
+        request(Request.api(
             path: "repos/\(owner)/\(repo)/pulls/\(number)/comments",
             method: .post,
             parameters: ["body": body, "in_reply_to": inReplyTo],

--- a/Classes/Repository/RepositoryClient.swift
+++ b/Classes/Repository/RepositoryClient.swift
@@ -155,7 +155,7 @@ final class RepositoryClient {
     func fetchReadme(
         completion: @escaping (Result<String>) -> Void
         ) {
-        githubClient.request(GithubClient.Request(
+        githubClient.request(GithubClient.Request.api(
             path: "repos/\(owner)/\(name)/readme",
             completion: { (response, _) in
                 if let json = response.value as? [String: Any],

--- a/Classes/Repository/RepositoryViewController.swift
+++ b/Classes/Repository/RepositoryViewController.swift
@@ -98,7 +98,7 @@ NewIssueTableViewControllerDelegate {
     }
 
     var repoUrl: URL {
-        return URL(string: "https://github.com/\(repo.owner)/\(repo.name)")!
+        return GithubClient.url(path: "\(repo.owner)/\(repo.name)")!
     }
 
     func configureNavigationItems() {

--- a/Classes/Settings/GithubClient+APIStatus.swift
+++ b/Classes/Settings/GithubClient+APIStatus.swift
@@ -15,18 +15,15 @@ extension GithubClient {
     }
 
     func fetchAPIStatus(completion: @escaping (Result<APIStatus>) -> Void) {
-        request(Request(
-            url: "https://status.github.com/api/status.json",
-            method: .get,
-            completion: { (response, _) in
-                if let json = response.value as? [String: Any],
-                    let statusString = json["status"] as? String,
-                    let status = APIStatus(rawValue: statusString) {
-                    completion(.success(status))
-                } else {
-                    completion(.error(nil))
-                }
-        }))
+        request(Request.status { (response, _) in
+            if let json = response.value as? [String: Any],
+                let statusString = json["status"] as? String,
+                let status = APIStatus(rawValue: statusString) {
+                completion(.success(status))
+            } else {
+                completion(.error(nil))
+            }
+        })
     }
 
 }

--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -90,7 +90,7 @@ NewIssueTableViewControllerDelegate {
     // MARK: Private API
 
     func onReviewAccess() {
-        guard let url = URL(string: "https://github.com/settings/connections/applications/\(Secrets.GitHub.clientId)")
+        guard let url = GithubClient.url(path: "settings/connections/applications/\(Secrets.GitHub.clientId)")
             else { fatalError("Should always create GitHub issue URL") }
         // iOS 11 login uses SFAuthenticationSession which shares credentials with Safari.app
         if #available(iOS 11.0, *) {
@@ -111,7 +111,7 @@ NewIssueTableViewControllerDelegate {
     }
     
     func onGitHubStatus() {
-        guard let url = URL(string: "https://status.github.com/messages")
+        guard let url = GithubClient.url(baseURL: "https://status.github.com/", path: "messages")
             else { fatalError("Should always create GitHub Status URL") }
         presentSafari(url: url)
     }

--- a/Classes/Systems/Alamofire+GithubAPI.swift
+++ b/Classes/Systems/Alamofire+GithubAPI.swift
@@ -33,7 +33,7 @@ func newGithubClient(
 
     let networker = Alamofire.SessionManager(configuration: config)
 
-    let gqlURL = URL(string: "https://api.github.com/graphql")!
+    let gqlURL = GithubClient.url(baseURL: "https://api.github.com/", path: "graphql")!
     let transport = HTTPNetworkTransport(url: gqlURL, configuration: config)
     let apollo = ApolloClient(networkTransport: transport)
 

--- a/Classes/Systems/BadgeNotifications.swift
+++ b/Classes/Systems/BadgeNotifications.swift
@@ -72,7 +72,7 @@ final class BadgeNotifications {
             else { return }
 
         let client = newGithubClient(sessionManager: manager, userSession: session)
-        client.request(GithubClient.Request(
+        client.request(GithubClient.Request.api(
             path: "notifications",
             method: .get,
             parameters: ["all": "false"],

--- a/Classes/Systems/GithubClient.swift
+++ b/Classes/Systems/GithubClient.swift
@@ -37,7 +37,7 @@ struct GithubClient {
             completion: @escaping (DataResponse<Any>, Page?) -> Void
             ) -> Request {
             return Request(
-                url: "https://api.github.com/" + path,
+                url: "https://api.github.com/\(path)",
                 method: method,
                 parameters: parameters,
                 headers: headers,
@@ -55,7 +55,7 @@ struct GithubClient {
             completion: @escaping (DataResponse<Any>, Page?) -> Void
             ) -> Request {
             return Request(
-                url: "https://github.com/" + path,
+                url: "https://github.com/\(path)",
                 method: method,
                 parameters: parameters,
                 headers: headers,
@@ -197,6 +197,10 @@ struct GithubClient {
             NetworkActivityIndicatorManager.shared.decrementActivityCount()
             resultHandler?(result, error)
         })
+    }
+
+    static func url(baseURL: String = "https://github.com/", path: String) -> URL? {
+        return URL(string: "\(baseURL)\(path)")
     }
 
 }

--- a/Classes/Systems/GithubClient.swift
+++ b/Classes/Systems/GithubClient.swift
@@ -28,15 +28,15 @@ struct GithubClient {
         let logoutOnAuthFailure: Bool
         let completion: (DataResponse<Any>, Page?) -> Void
 
-        init(
+        static func api(
             path: String,
             method: HTTPMethod = .get,
             parameters: Parameters? = nil,
             headers: HTTPHeaders? = nil,
             logoutOnAuthFailure: Bool = true,
             completion: @escaping (DataResponse<Any>, Page?) -> Void
-            ) {
-            self.init(
+            ) -> Request {
+            return Request(
                 url: "https://api.github.com/" + path,
                 method: method,
                 parameters: parameters,
@@ -46,7 +46,42 @@ struct GithubClient {
             )
         }
 
-        init(
+        static func site(
+            path: String,
+            method: HTTPMethod = .get,
+            parameters: Parameters? = nil,
+            headers: HTTPHeaders? = nil,
+            logoutOnAuthFailure: Bool = true,
+            completion: @escaping (DataResponse<Any>, Page?) -> Void
+            ) -> Request {
+            return Request(
+                url: "https://github.com/" + path,
+                method: method,
+                parameters: parameters,
+                headers: headers,
+                logoutOnAuthFailure: logoutOnAuthFailure,
+                completion: completion
+            )
+        }
+
+        static func status(
+            method: HTTPMethod = .get,
+            parameters: Parameters? = nil,
+            headers: HTTPHeaders? = nil,
+            logoutOnAuthFailure: Bool = true,
+            completion: @escaping (DataResponse<Any>, Page?) -> Void
+            ) -> Request {
+            return Request(
+                url: "https://status.github.com/api/status.json",
+                method: method,
+                parameters: parameters,
+                headers: headers,
+                logoutOnAuthFailure: logoutOnAuthFailure,
+                completion: completion
+            )
+        }
+
+        private init(
             url: String,
             method: HTTPMethod = .get,
             parameters: Parameters? = nil,

--- a/Classes/Utility/AlertAction.swift
+++ b/Classes/Utility/AlertAction.swift
@@ -54,7 +54,7 @@ struct AlertAction {
 
     func view(owner: String) -> UIAlertAction {
         return UIAlertAction(title: "@\(owner)", style: .default) { _ in
-            guard let url = URL(string: "https://github.com/\(owner)") else { return }
+            guard let url = GithubClient.url(path: owner) else { return }
             self.rootViewController?.presentSafari(url: url)
         }
     }

--- a/Classes/View Controllers/CreateProfileViewController.swift
+++ b/Classes/View Controllers/CreateProfileViewController.swift
@@ -10,6 +10,6 @@ import UIKit
 import SafariServices
 
 func CreateProfileViewController(login: String) -> UIViewController {
-    let url = URL(string: "https://github.com/\(login)")!
+    let url = GithubClient.url(path: login)!
 	return try! SFSafariViewController.configured(with: url)
 }

--- a/Classes/View Controllers/UIViewController+Safari.swift
+++ b/Classes/View Controllers/UIViewController+Safari.swift
@@ -21,17 +21,17 @@ extension UIViewController {
     }
 
     func presentCommit(owner: String, repo: String, hash: String) {
-        guard let url = URL(string: "https://github.com/\(owner)/\(repo)/commit/\(hash)") else { return }
+        guard let url = GithubClient.url(path: "\(owner)/\(repo)/commit/\(hash)") else { return }
         presentSafari(url: url)
     }
 
     func presentLabels(owner: String, repo: String, label: String) {
-        guard let url = URL(string: "https://github.com/\(owner)/\(repo)/labels/\(label)") else { return }
+        guard let url = GithubClient.url(path: "\(owner)/\(repo)/labels/\(label)") else { return }
         presentSafari(url: url)
     }
 
     func presentMilestone(owner: String, repo: String, milestone: Int) {
-        guard let url = URL(string: "https://github.com/\(owner)/\(repo)/milestone/\(milestone)") else { return }
+        guard let url = GithubClient.url(path: "\(owner)/\(repo)/milestone/\(milestone)") else { return }
         presentSafari(url: url)
     }
 


### PR DESCRIPTION
This moves some String-dependant URLs to the GithubClient, making it easier to support Enterprise at some point.