### PR TITLE
Only save selections as recent searches

### DIFF
--- a/Classes/Search/SearchViewController.swift
+++ b/Classes/Search/SearchViewController.swift
@@ -126,7 +126,6 @@ SearchResultSectionControllerDelegate {
     func search(term: String) {
         let query: SearchQuery = .search(term)
         guard canSearch(query: query) else { return }
-        recentStore.add(query)
 
         let request = client.search(query: term, containerWidth: view.bounds.width) { [weak self] resultType in
             guard let state = self?.state, case .loading = state else { return }


### PR DESCRIPTION
This resolves #1557 with the agreed upon solution.

We'll only save user selections as recent searches and not query terms.