### PR TITLE
Refactoring shortcut handler to use enum based Routes

### DIFF
--- a/Classes/Systems/AppDelegate.swift
+++ b/Classes/Systems/AppDelegate.swift
@@ -68,7 +68,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
-        completionHandler(ShortcutHandler.handle(shortcutItem: shortcutItem,
+        guard let route = Route(shortcutItem: shortcutItem) else {
+            completionHandler(false)
+            return
+        }
+        completionHandler(ShortcutHandler.handle(route: route,
                                                  sessionManager: sessionManager,
                                                  navigationManager: rootNavigationManager))
     }

--- a/Classes/Systems/RootNavigationManager.swift
+++ b/Classes/Systems/RootNavigationManager.swift
@@ -89,6 +89,12 @@ final class RootNavigationManager: GithubSessionListener {
         return tabBarController?.selectedViewController
     }
 
+    @discardableResult
+    public func selectViewController(atTab tab: TabBarController.Tab) -> UIViewController? {
+        tabBarController?.showTab(tab)
+        return tabBarController?.selectedViewController
+    }
+
     // MARK: GithubSessionListener
 
     func didFocus(manager: GithubSessionManager, userSession: GithubUserSession, dismiss: Bool) {
@@ -141,8 +147,8 @@ final class RootNavigationManager: GithubSessionListener {
         return rootViewController?.viewControllers.last as? UINavigationController
     }
 
-    private var tabBarController: UITabBarController? {
-        return rootViewController?.viewControllers.first as? UITabBarController
+    private var tabBarController: TabBarController? {
+        return rootViewController?.viewControllers.first as? TabBarController
     }
 
     private func newLoginViewController() -> UIViewController {

--- a/Classes/Systems/Route.swift
+++ b/Classes/Systems/Route.swift
@@ -1,0 +1,23 @@
+//
+//  Navigation.swift
+//  Freetime
+//
+//  Created by Rizwan on 26/02/18.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import Foundation
+
+enum Route {
+    case tab(TabBarController.Tab)
+    case switchAccount(sessionIndex: Int?)
+
+    init?(shortcutItem: UIApplicationShortcutItem) {
+        guard let itemType = ShortcutHandler.Items(rawValue: shortcutItem.type) else { return nil }
+        switch itemType {
+        case .search: self = .tab(.search)
+        case .bookmarks: self = .tab(.bookmarks)
+        case .switchAccount: self = .switchAccount(sessionIndex: shortcutItem.userInfo?["sessionIndex"] as? Int)
+        }
+    }
+}

--- a/Classes/Systems/ShortcutHandler.swift
+++ b/Classes/Systems/ShortcutHandler.swift
@@ -10,10 +10,7 @@ import Foundation
 
 struct ShortcutHandler {
 
-    static private let searchViewControllerIndex = 1
-    static private let bookmarksViewControllerIndex = 2
-
-    private enum Items: String {
+    enum Items: String {
         case search
         case bookmarks
         case switchAccount
@@ -23,19 +20,17 @@ struct ShortcutHandler {
         application.shortcutItems = generateItems(sessionManager: sessionManager)
     }
 
-    static func handle(shortcutItem item: UIApplicationShortcutItem,
-                       sessionManager: GithubSessionManager,
-                       navigationManager: RootNavigationManager) -> Bool {
-        guard let itemType = Items(rawValue: item.type) else { return false }
-        switch itemType {
-        case .search:
-            navigationManager.selectViewController(atIndex: searchViewControllerIndex)
+    static func handle(
+        route: Route,
+        sessionManager: GithubSessionManager,
+        navigationManager: RootNavigationManager
+        ) -> Bool {
+        switch route {
+        case .tab(let tab):
+            navigationManager.selectViewController(atTab: tab)
             return true
-        case .bookmarks:
-            navigationManager.selectViewController(atIndex: bookmarksViewControllerIndex)
-            return true
-        case .switchAccount:
-            if let index = item.userInfo?["sessionIndex"] as? Int {
+        case .switchAccount(let sessionIndex):
+            if let index = sessionIndex {
                 let session = sessionManager.userSessions[index]
                 sessionManager.focus(session, dismiss: false)
             }
@@ -57,9 +52,9 @@ struct ShortcutHandler {
         // Bookmarks
         let bookmarkIcon = UIApplicationShortcutIcon(templateImageName: "bookmark")
         let bookmarkItem = UIApplicationShortcutItem(type: Items.bookmarks.rawValue,
-                                                   localizedTitle: Constants.Strings.bookmarks,
-                                                   localizedSubtitle: nil,
-                                                   icon: bookmarkIcon)
+                                                     localizedTitle: Constants.Strings.bookmarks,
+                                                     localizedSubtitle: nil,
+                                                     icon: bookmarkIcon)
         items.append(bookmarkItem)
         
         // Switchuser

--- a/Classes/View Controllers/TabBarController.swift
+++ b/Classes/View Controllers/TabBarController.swift
@@ -1,0 +1,22 @@
+//
+//  TabBarController.swift
+//  Freetime
+//
+//  Created by Rizwan on 26/02/18.
+//  Copyright © 2018 Ryan Nystrom. All rights reserved.
+//
+
+import Foundation
+
+final class TabBarController: UITabBarController {
+    enum Tab: Int {
+        case inbox = 0
+        case search = 1
+        case bookmarks = 2
+        case settings = 3
+    }
+
+    func showTab(_ tab: Tab) {
+        selectedIndex = tab.rawValue
+    }
+}

--- a/Freetime.xcodeproj/project.pbxproj
+++ b/Freetime.xcodeproj/project.pbxproj
@@ -373,6 +373,8 @@
 		54AD5E8E1F24D953004A4BD6 /* FeedSelectionProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54AD5E8D1F24D953004A4BD6 /* FeedSelectionProviding.swift */; };
 		5DB4DD471FC5C10000DF7ABF /* Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB4DD461FC5C10000DF7ABF /* Accessibility.swift */; };
 		620FD1910224D67E26A05955 /* Pods_FreetimeTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7EF1344D18510D671EAD0A1 /* Pods_FreetimeTests.framework */; };
+		65A315292044369D0074E3B6 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A315282044369D0074E3B6 /* TabBarController.swift */; };
+		65A3152B2044376D0074E3B6 /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A3152A2044376D0074E3B6 /* Route.swift */; };
 		754488B11F7ADF8D0032D08C /* UIAlertController+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754488B01F7ADF8D0032D08C /* UIAlertController+Action.swift */; };
 		75468F7A1F7AFBC800F2BC19 /* AlertActionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75468F791F7AFBC800F2BC19 /* AlertActionBuilder.swift */; };
 		75A0ACF51F79A82D0062D99A /* AlertAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A0ACF41F79A82D0062D99A /* AlertAction.swift */; };
@@ -818,6 +820,8 @@
 		49FFF4331F9FC83200335568 /* HapticFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticFeedback.swift; sourceTree = "<group>"; };
 		54AD5E8D1F24D953004A4BD6 /* FeedSelectionProviding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedSelectionProviding.swift; sourceTree = "<group>"; };
 		5DB4DD461FC5C10000DF7ABF /* Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessibility.swift; sourceTree = "<group>"; };
+		65A315282044369D0074E3B6 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
+		65A3152A2044376D0074E3B6 /* Route.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Route.swift; sourceTree = "<group>"; };
 		754488B01F7ADF8D0032D08C /* UIAlertController+Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Action.swift"; sourceTree = "<group>"; };
 		75468F791F7AFBC800F2BC19 /* AlertActionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertActionBuilder.swift; sourceTree = "<group>"; };
 		75A0ACF41F79A82D0062D99A /* AlertAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertAction.swift; sourceTree = "<group>"; };
@@ -1455,6 +1459,7 @@
 				298BA08C1EC90A9000B01946 /* NSAttributedStringSizing.swift */,
 				292CD3D31F0DC12100D3D57B /* PhotoViewHandler.swift */,
 				2980033A1F51E82400BE90F4 /* Rating */,
+				65A3152A2044376D0074E3B6 /* Route.swift */,
 				293189271F5391F700EF0911 /* Result.swift */,
 				29316DC21ECC981D007CAE3F /* RootNavigationManager.swift */,
 				294A3D751FB29843000E81A4 /* ScrollViewKeyboardAdjuster.swift */,
@@ -1496,6 +1501,7 @@
 				D8D876F71FB6083200A57E2B /* UIPopoverPresentationController+SourceView.swift */,
 				29792B181FFB10A3007A0C57 /* UIViewController+MessageAutocompleteControllerLayoutDelegate.swift */,
 				29136BE2200AAA5A007317BE /* UIViewController+FilePathTitle.swift */,
+				65A315282044369D0074E3B6 /* TabBarController.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -2489,6 +2495,7 @@
 				DCA5ED101FAEDF290072F074 /* BookmarkStore.swift in Sources */,
 				295C31CD1F0AA55400521CED /* IssueStatusEvent.swift in Sources */,
 				295840671EE89FE4007723C6 /* IssueStatusEventCell.swift in Sources */,
+				65A315292044369D0074E3B6 /* TabBarController.swift in Sources */,
 				295840651EE89F28007723C6 /* IssueStatusEventModel.swift in Sources */,
 				295840691EE8A328007723C6 /* IssueStatusEventSectionController.swift in Sources */,
 				294563E61EE4EE6F00DBCD35 /* IssueStatusModel.swift in Sources */,
@@ -2644,6 +2651,7 @@
 				2993046B1FBA8C04007B9737 /* IssueManagingExpansionCell.swift in Sources */,
 				29C33FDB1F127DBB00EC8D40 /* SplitPlaceholderViewController.swift in Sources */,
 				29AC90E51F00A7C8000B80E4 /* SplitViewControllerDelegate.swift in Sources */,
+				65A3152B2044376D0074E3B6 /* Route.swift in Sources */,
 				29DB264A1FCA10A800C3D0C9 /* GithubHighlighting.swift in Sources */,
 				29A08FC11F12F08100C5368E /* String+HashDisplay.swift in Sources */,
 				29B0EF871F93DF6C00870291 /* RepositoryCodeBlobViewController.swift in Sources */,

--- a/Resources/Base.lproj/Main.storyboard
+++ b/Resources/Base.lproj/Main.storyboard
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="EPN-4V-9Hj">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="EPN-4V-9Hj">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -15,11 +14,10 @@
                 <navigationController id="AKn-8S-pzd" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Notifications" image="inbox" id="KQ4-AC-rKh"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="crz-Uj-ajM">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="0yd-OZ-kRG">
-                        <rect key="frame" x="0.0" y="623" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" red="0.011764705882352941" green="0.40000000000000002" blue="0.83921568627450982" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </toolbar>
@@ -55,7 +53,7 @@
             <objects>
                 <navigationController id="D4E-Yy-PTN" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="v0t-Sf-PfR">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -79,7 +77,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="splash-light" translatesAutoresizingMaskIntoConstraints="NO" id="NEt-Y3-0Rg">
-                                <rect key="frame" x="101" y="247" width="173" height="173"/>
+                                <rect key="frame" x="100.5" y="246.5" width="174" height="174"/>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
@@ -110,9 +108,10 @@
         <!--Tab Bar Controller-->
         <scene sceneID="gc3-YD-4oz">
             <objects>
-                <tabBarController automaticallyAdjustsScrollViewInsets="NO" id="f5k-7G-hod" sceneMemberID="viewController">
+                <tabBarController automaticallyAdjustsScrollViewInsets="NO" id="f5k-7G-hod" customClass="TabBarController" customModule="Freetime" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
                     <tabBar key="tabBar" contentMode="scaleToFill" id="FXG-86-zX1">
+                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                         <color key="selectedImageTintColor" red="0.19215686269999999" green="0.3411764706" blue="0.63137254899999995" alpha="1" colorSpace="calibratedRGB"/>
@@ -127,8 +126,8 @@
         </scene>
     </scenes>
     <resources>
-        <image name="inbox" width="16" height="16"/>
-        <image name="splash-light" width="173" height="173"/>
+        <image name="inbox" width="22" height="25"/>
+        <image name="splash-light" width="174" height="174"/>
     </resources>
     <color key="tintColor" red="0.011764705882352941" green="0.40000000000000002" blue="0.83921568627450982" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
 </document>


### PR DESCRIPTION
Hopefully fixes #708 and give us a way of handling deep linking possibilities.

- Adds `Route` enum with possible routes - extensible 
- Adds `TabBarController` with `Tab` enum
- Refactores `ShortCutHandler` to use `Route`

Now adding deep linking with `Route` is as easy as like below

```swift
init?(url: URL) {
        switch url.absoluteString {
        case "\(scheme)://tab/inbox": self = .tab(.inbox)
        case "\(scheme)://tab/search": self = .tab(.search)
        case "\(scheme)://tab/bookmars": self = .tab(.bookmarks)
        case "\(scheme)://tab/settings": self = .tab(.settings)
        default: return nil
        }
    }
```

Not sure this is the right/scalable way. Feel free to comment/suggest/close this PR.